### PR TITLE
feat(xray): cache agent metadata in store

### DIFF
--- a/src/components/xray/XRayPanel.tsx
+++ b/src/components/xray/XRayPanel.tsx
@@ -13,21 +13,27 @@ type XRayPanelProps = { agentKey: string | null; onClose: () => void }
 
 export function XRayPanel({ agentKey, onClose }: XRayPanelProps) {
   const agent = useAgentStore((s) => (agentKey ? s.agents.get(agentKey) : undefined))
-  const [metadata, setMetadata] = useState<AgentMetadata | null>(null)
+  const cacheMetadata = useAgentStore((s) => s.cacheMetadata)
+  const [metadata, setMetadata] = useState<AgentMetadata | null>(agent?.metadata ?? null)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState(false)
 
   useEffect(() => {
     if (!agent?.agentURI) return
+    if (agent.metadata) {
+      setMetadata(agent.metadata)
+      return
+    }
     setLoading(true)
     setError(false)
     fetchAgentMetadata(agent.agentURI)
       .then((result) => {
         if (!result && agent.agentURI) setError(true)
         setMetadata(result)
+        if (result && agentKey) cacheMetadata(agentKey, result)
       })
       .finally(() => setLoading(false))
-  }, [agent?.agentURI])
+  }, [agent?.agentURI, agent?.metadata, agentKey, cacheMetadata])
 
   const enriched = agent ? { ...agent, metadata: metadata ?? agent.metadata } : null
 
@@ -39,6 +45,7 @@ export function XRayPanel({ agentKey, onClose }: XRayPanelProps) {
       .then((result) => {
         if (!result && agent.agentURI) setError(true)
         setMetadata(result)
+        if (result && agentKey) cacheMetadata(agentKey, result)
       })
       .finally(() => setLoading(false))
   }

--- a/src/stores/agents.ts
+++ b/src/stores/agents.ts
@@ -1,10 +1,11 @@
 import { create } from 'zustand'
-import type { AgentSummary } from '@/types/agents'
+import type { AgentSummary, AgentMetadata } from '@/types/agents'
 import type { ScopeEvent, FeedbackData } from '@/types/events'
 
 type AgentStoreState = {
   agents: Map<string, AgentSummary>
   upsertFromEvent: (event: ScopeEvent) => void
+  cacheMetadata: (key: string, metadata: AgentMetadata) => void
   clear: () => void
 }
 
@@ -38,6 +39,7 @@ export const useAgentStore = create<AgentStoreState>()((set, get) => ({
       case 'uri_update': {
         const d = event.data as { newURI: string }
         existing.agentURI = d.newURI
+        existing.metadata = undefined
         break
       }
       case 'feedback': {
@@ -50,6 +52,14 @@ export const useAgentStore = create<AgentStoreState>()((set, get) => ({
     }
 
     agents.set(key, { ...existing })
+    set({ agents })
+  },
+
+  cacheMetadata: (key, metadata) => {
+    const agents = new Map(get().agents)
+    const existing = agents.get(key)
+    if (!existing) return
+    agents.set(key, { ...existing, metadata })
     set({ agents })
   },
 


### PR DESCRIPTION
## Summary
- Add `cacheMetadata` action to `useAgentStore` — writes metadata into the agent entry after first fetch
- Skip fetch in `XRayPanel` when `agent.metadata` exists (cache hit) — instant reopen
- Invalidate cached metadata on `uri_update` events so stale data is never served
- Retry button bypasses cache and always re-fetches

Closes #45

## Test plan
- [x] `pnpm build` — compiles successfully
- [x] `pnpm test` — 45/45 tests pass
- [ ] `pnpm dev` → open XRayPanel → close → reopen → instant (no loading spinner)
- [ ] Trigger `uri_update` event → metadata clears → next open re-fetches

Wolfcito 🐾 @akawolfcito