### PR TITLE
feat: M7 x402 Trust Oracle

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,9 @@ NEXT_PUBLIC_CELO_SEPOLIA_RPC_URL=https://celo-sepolia.g.alchemy.com/v2/YOUR_API_
 NEXT_PUBLIC_SUPABASE_URL=https://ioxjqabngtannnfsueqa.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
 SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+
+# x402 Micropayments (optional — enables pay-per-call on /score and /signals)
+X402_PAY_TO=0xYOUR_WALLET_ADDRESS
+X402_NETWORK=eip155:42220
+X402_ASSET_ADDRESS=0xcebA9300f2b948710d2653dD7B07f33A8B32118C
+X402_FACILITATOR_URL=https://facilitator.ultravioletadao.xyz

--- a/src/app/api/v1/agent/[chain]/[id]/score/route.ts
+++ b/src/app/api/v1/agent/[chain]/[id]/score/route.ts
@@ -1,17 +1,23 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { supabaseAdmin } from '@/lib/supabase/admin'
-import { authenticateApiKey, buildRateLimitHeaders } from '@/lib/api-keys/authenticate'
+import { authenticateHybrid, buildHybridHeaders } from '@/lib/x402/middleware'
+import { recordX402Payment } from '@/lib/x402/payments'
 import { toTrustScore } from '@/types/trust-score'
 
 type RouteParams = { params: Promise<{ chain: string; id: string }> }
 
 export async function GET(req: NextRequest, { params }: RouteParams) {
-  const auth = await authenticateApiKey(req.headers)
-  if (!auth.ok) return auth.error
-
   const { chain, id } = await params
   const chainId = Number(chain)
   const agentId = Number(id)
+
+  const endpointPath = `/api/v1/agent/${chain}/${id}/score`
+  const auth = await authenticateHybrid(req.headers, {
+    path: endpointPath,
+    priceKey: 'score',
+    description: 'Trust score query for ERC-8004 agent',
+  })
+  if (!auth.ok) return auth.error
 
   if (!chainId || !agentId) {
     return NextResponse.json({ error: 'Invalid chain or agent ID' }, { status: 400 })
@@ -29,6 +35,11 @@ export async function GET(req: NextRequest, { params }: RouteParams) {
       { error: 'Trust score not available. Agent may have no events yet.' },
       { status: 404 }
     )
+  }
+
+  // Record x402 payment (fire-and-forget)
+  if (auth.method === 'x402') {
+    recordX402Payment({ chainId, agentId, endpoint: endpointPath, x402: auth.x402, priceKey: 'score' })
   }
 
   const score = toTrustScore(data)
@@ -52,5 +63,5 @@ export async function GET(req: NextRequest, { params }: RouteParams) {
       updatedAt: score.updatedAt,
     },
     formula: 'https://denscope.vercel.app/docs/api#trust-score-formula',
-  }, { headers: buildRateLimitHeaders(auth.rateLimit) })
+  }, { headers: buildHybridHeaders(auth) })
 }

--- a/src/app/api/v1/agent/[chain]/[id]/signals/route.ts
+++ b/src/app/api/v1/agent/[chain]/[id]/signals/route.ts
@@ -1,16 +1,22 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { supabaseAdmin } from '@/lib/supabase/admin'
-import { authenticateApiKey, buildRateLimitHeaders } from '@/lib/api-keys/authenticate'
+import { authenticateHybrid, buildHybridHeaders } from '@/lib/x402/middleware'
+import { recordX402Payment } from '@/lib/x402/payments'
 
 type RouteParams = { params: Promise<{ chain: string; id: string }> }
 
 export async function GET(req: NextRequest, { params }: RouteParams) {
-  const auth = await authenticateApiKey(req.headers)
-  if (!auth.ok) return auth.error
-
   const { chain, id } = await params
   const chainId = Number(chain)
   const agentId = Number(id)
+
+  const endpointPath = `/api/v1/agent/${chain}/${id}/signals`
+  const auth = await authenticateHybrid(req.headers, {
+    path: endpointPath,
+    priceKey: 'signals',
+    description: 'Risk signals for ERC-8004 agent',
+  })
+  if (!auth.ok) return auth.error
 
   if (!chainId || !agentId) {
     return NextResponse.json({ error: 'Invalid chain or agent ID' }, { status: 400 })
@@ -34,6 +40,11 @@ export async function GET(req: NextRequest, { params }: RouteParams) {
 
   const { data } = await query
 
+  // Record x402 payment (fire-and-forget)
+  if (auth.method === 'x402') {
+    recordX402Payment({ chainId, agentId, endpoint: endpointPath, x402: auth.x402, priceKey: 'signals' })
+  }
+
   const signals = (data ?? []).map((row) => ({
     id: row.id,
     signalKind: row.signal_kind,
@@ -48,6 +59,6 @@ export async function GET(req: NextRequest, { params }: RouteParams) {
 
   return NextResponse.json(
     { signals, count: signals.length },
-    { headers: buildRateLimitHeaders(auth.rateLimit) }
+    { headers: buildHybridHeaders(auth) }
   )
 }

--- a/src/app/docs/api/page.tsx
+++ b/src/app/docs/api/page.tsx
@@ -31,11 +31,27 @@ export default function ApiDocsPage() {
 
         <Section title="Authentication">
           <p className="text-sm text-text-secondary">
-            All endpoints require an API key. Pass it via:
+            Two authentication methods are supported. Use whichever fits your use case:
+          </p>
+
+          <h4 className="text-xs text-text-muted uppercase font-mono mt-4 mb-2">Option 1: API Key (for developers)</h4>
+          <p className="text-sm text-text-secondary">
+            Best for bulk integrations, dashboards, and analytics. Get a key from the Console.
           </p>
           <ul className="list-disc list-inside text-sm text-text-secondary mt-2 space-y-1">
             <li><code className="text-xs font-mono">Authorization: Bearer ds_...</code> (recommended)</li>
             <li><code className="text-xs font-mono">X-API-Key: ds_...</code></li>
+          </ul>
+
+          <h4 className="text-xs text-text-muted uppercase font-mono mt-4 mb-2">Option 2: x402 Payment (for agents)</h4>
+          <p className="text-sm text-text-secondary">
+            Any wallet can query trust data with zero setup. No API key, no account needed.
+            Available on <code className="text-xs font-mono">/score</code> and <code className="text-xs font-mono">/signals</code> endpoints.
+          </p>
+          <ul className="list-disc list-inside text-sm text-text-secondary mt-2 space-y-1">
+            <li>Call the endpoint without auth &rarr; receive HTTP 402 + <code className="text-xs font-mono">PAYMENT-REQUIRED</code> header</li>
+            <li>Sign an EIP-712 authorization (off-chain, no gas)</li>
+            <li>Retry with <code className="text-xs font-mono">X-PAYMENT</code> header &rarr; receive the data</li>
           </ul>
         </Section>
 
@@ -58,12 +74,12 @@ export default function ApiDocsPage() {
           <Endpoint
             method="GET"
             path="/api/v1/agent/{chain}/{id}/score"
-            desc="Trust score (0-100) with confidence level and component breakdown."
+            desc="Trust score (0-100) with confidence level and component breakdown. Supports x402 ($0.001/call)."
           />
           <Endpoint
             method="GET"
             path="/api/v1/agent/{chain}/{id}/signals"
-            desc="Active incidents/signals. Query param: ?status=open|resolved|all"
+            desc="Active incidents/signals. Query param: ?status=open|resolved|all. Supports x402 ($0.0005/call)."
           />
           <Endpoint
             method="GET"
@@ -99,6 +115,41 @@ export default function ApiDocsPage() {
           </div>
         </Section>
 
+        <Section title="x402 Payment Flow" id="x402-payment-flow">
+          <p className="text-sm text-text-secondary">
+            The <code className="text-xs font-mono">/score</code> and <code className="text-xs font-mono">/signals</code> endpoints
+            accept x402 micropayments via the UltravioletaDAO facilitator on Celo. This enables autonomous agents to query trust
+            data without human-managed API keys.
+          </p>
+
+          <h4 className="text-xs text-text-muted uppercase font-mono mt-4 mb-2">Flow</h4>
+          <CodeBlock>{`# 1. Call without auth -> get 402 with payment instructions
+curl -i https://denscope.vercel.app/api/v1/agent/42220/5/score
+# HTTP/2 402
+# PAYMENT-REQUIRED: <base64-encoded JSON>
+
+# 2. Decode PAYMENT-REQUIRED header -> sign EIP-712 off-chain
+
+# 3. Retry with X-PAYMENT header
+curl -H "X-PAYMENT: <base64-encoded payment>" \\
+  https://denscope.vercel.app/api/v1/agent/42220/5/score
+# HTTP/2 200 { score: { value: 85, ... } }`}</CodeBlock>
+
+          <h4 className="text-xs text-text-muted uppercase font-mono mt-4 mb-2">Pricing</h4>
+          <Table headers={['Endpoint', 'Price (USDC)', 'micro-USDC']}>
+            <Row cells={['/score', '$0.001', '1000']} />
+            <Row cells={['/signals', '$0.0005', '500']} />
+          </Table>
+
+          <h4 className="text-xs text-text-muted uppercase font-mono mt-4 mb-2">Details</h4>
+          <ul className="list-disc list-inside text-sm text-text-secondary mt-2 space-y-1">
+            <li>Protocol: x402 v2 (HTTP 402 Payment Required)</li>
+            <li>Settlement: EIP-3009 TransferWithAuthorization (off-chain signature, no gas for the caller)</li>
+            <li>Stablecoin: USDC on Celo (chain ID 42220)</li>
+            <li>Facilitator: UltravioletaDAO (<code className="text-xs font-mono">facilitator.ultravioletadao.xyz</code>)</li>
+          </ul>
+        </Section>
+
         <Section title="Supported Chains">
           <Table headers={['Chain', 'Chain ID']}>
             <Row cells={['Celo Mainnet', '42220']} />
@@ -110,6 +161,7 @@ export default function ApiDocsPage() {
           <Table headers={['Status', 'Meaning']}>
             <Row cells={['400', 'Invalid parameters']} />
             <Row cells={['401', 'Missing or invalid API key']} />
+            <Row cells={['402', 'Payment required (x402 — see PAYMENT-REQUIRED header)']} />
             <Row cells={['403', 'API key disabled']} />
             <Row cells={['404', 'Agent or score not found']} />
             <Row cells={['429', 'Rate limit exceeded']} />

--- a/src/lib/x402/__tests__/config.test.ts
+++ b/src/lib/x402/__tests__/config.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+describe('x402 config', () => {
+  const originalEnv = process.env
+
+  beforeEach(() => {
+    vi.resetModules()
+    process.env = { ...originalEnv }
+  })
+
+  afterEach(() => {
+    process.env = originalEnv
+  })
+
+  it('uses Celo mainnet defaults when no env vars set', async () => {
+    delete process.env.X402_PAY_TO
+    delete process.env.X402_NETWORK
+    const { x402Config, isX402Enabled } = await import('../config')
+    expect(x402Config.network).toBe('eip155:42220')
+    expect(x402Config.facilitatorUrl).toBe('https://facilitator.ultravioletadao.xyz')
+    expect(isX402Enabled()).toBe(false)
+  })
+
+  it('reads env vars when present', async () => {
+    process.env.X402_PAY_TO = '0xABC'
+    process.env.X402_NETWORK = 'eip155:11142220'
+    const { x402Config, isX402Enabled } = await import('../config')
+    expect(x402Config.payTo).toBe('0xABC')
+    expect(x402Config.network).toBe('eip155:11142220')
+    expect(isX402Enabled()).toBe(true)
+  })
+
+  it('has correct default pricing', async () => {
+    const { x402Config } = await import('../config')
+    expect(x402Config.pricing.score).toBe(0.001)
+    expect(x402Config.pricing.signals).toBe(0.0005)
+  })
+})

--- a/src/lib/x402/__tests__/facilitator.test.ts
+++ b/src/lib/x402/__tests__/facilitator.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+vi.mock('../config', () => ({
+  x402Config: {
+    facilitatorUrl: 'https://facilitator.test',
+  },
+}))
+
+import { verifyX402Payment, settleX402Payment } from '../facilitator'
+import type { PaymentRequirement } from '../types'
+
+const mockRequirements: PaymentRequirement = {
+  scheme: 'exact',
+  network: 'eip155:42220',
+  amount: '1000',
+  asset: '0xUSDC',
+  payTo: '0xPAYTO',
+  maxTimeoutSeconds: 30,
+  extra: { assetTransferMethod: 'eip3009', name: 'USD Coin', version: '2' },
+}
+
+// Encode a fake X-PAYMENT header
+const fakePayload = { x402Version: 2, payload: { signature: '0xSIG' } }
+const fakePaymentHeader = Buffer.from(JSON.stringify(fakePayload)).toString('base64')
+
+describe('verifyX402Payment', () => {
+  beforeEach(() => { vi.restoreAllMocks() })
+
+  it('returns valid result on successful verify', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify({ isValid: true, payer: '0xAGENT', network: 'eip155:42220' }), { status: 200 })
+    )
+
+    const result = await verifyX402Payment(fakePaymentHeader, mockRequirements)
+    expect(result.valid).toBe(true)
+    expect(result.payer).toBe('0xAGENT')
+  })
+
+  it('returns error on invalid payment', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify({ isValid: false, invalidReason: 'bad signature' }), { status: 200 })
+    )
+
+    const result = await verifyX402Payment(fakePaymentHeader, mockRequirements)
+    expect(result.valid).toBe(false)
+    expect(result.error).toBe('bad signature')
+  })
+
+  it('returns error on HTTP failure', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response('server error', { status: 500 })
+    )
+
+    const result = await verifyX402Payment(fakePaymentHeader, mockRequirements)
+    expect(result.valid).toBe(false)
+    expect(result.error).toContain('500')
+  })
+
+  it('returns error on network failure', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValueOnce(new Error('network down'))
+
+    const result = await verifyX402Payment(fakePaymentHeader, mockRequirements)
+    expect(result.valid).toBe(false)
+    expect(result.error).toContain('network down')
+  })
+})
+
+describe('settleX402Payment', () => {
+  beforeEach(() => { vi.restoreAllMocks() })
+
+  it('returns success with tx hash on successful settle', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({ success: true, transaction: '0xTXHASH', network: 'eip155:42220', payer: '0xAGENT' }),
+        { status: 200 }
+      )
+    )
+
+    const result = await settleX402Payment(fakePaymentHeader, mockRequirements)
+    expect(result.success).toBe(true)
+    expect(result.transaction).toBe('0xTXHASH')
+    expect(result.payer).toBe('0xAGENT')
+  })
+
+  it('returns error on failed settlement', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify({ success: false, errorReason: 'insufficient funds' }), { status: 200 })
+    )
+
+    const result = await settleX402Payment(fakePaymentHeader, mockRequirements)
+    expect(result.success).toBe(false)
+    expect(result.error).toBe('insufficient funds')
+  })
+
+  it('returns error on HTTP failure', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response('bad gateway', { status: 502 })
+    )
+
+    const result = await settleX402Payment(fakePaymentHeader, mockRequirements)
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('502')
+  })
+})

--- a/src/lib/x402/__tests__/middleware.test.ts
+++ b/src/lib/x402/__tests__/middleware.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Mock dependencies
+vi.mock('../config', () => ({
+  x402Config: {
+    payTo: '0xPAYTO',
+    network: 'eip155:42220',
+    assetAddress: '0xUSDC',
+    assetName: 'USD Coin',
+    baseUrl: 'https://denscope.vercel.app',
+    facilitatorUrl: 'https://facilitator.test',
+    pricing: { score: 0.001, signals: 0.0005 },
+  },
+  isX402Enabled: () => true,
+}))
+
+vi.mock('@/lib/api-keys/authenticate', () => ({
+  extractApiKey: vi.fn(),
+  authenticateApiKey: vi.fn(),
+  buildRateLimitHeaders: vi.fn(() => ({
+    'X-RateLimit-Limit': '100',
+    'X-RateLimit-Remaining': '99',
+    'X-RateLimit-Reset': '2026-02-17T00:00:00.000Z',
+  })),
+}))
+
+vi.mock('../facilitator', () => ({
+  verifyX402Payment: vi.fn(),
+  settleX402Payment: vi.fn(),
+}))
+
+import { authenticateHybrid, buildHybridHeaders } from '../middleware'
+import { extractApiKey, authenticateApiKey } from '@/lib/api-keys/authenticate'
+import { verifyX402Payment, settleX402Payment } from '../facilitator'
+
+const endpoint = { path: '/api/v1/agent/42220/5/score', priceKey: 'score', description: 'Trust score' }
+
+describe('authenticateHybrid', () => {
+  beforeEach(() => {
+    vi.mocked(extractApiKey).mockReturnValue(null)
+  })
+
+  it('delegates to API key auth when key is present', async () => {
+    vi.mocked(extractApiKey).mockReturnValue('ds_abc123')
+    vi.mocked(authenticateApiKey).mockResolvedValue({
+      ok: true,
+      keyId: 'key-1',
+      rateLimit: { limited: false, remaining: 99, limit: 100, resetAt: '2026-02-17T00:00:00.000Z' },
+    })
+
+    const headers = new Headers({ Authorization: 'Bearer ds_abc123' })
+    const result = await authenticateHybrid(headers, endpoint)
+
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.method).toBe('api-key')
+    }
+  })
+
+  it('processes x402 payment when X-PAYMENT header is present', async () => {
+    const fakePayload = { x402Version: 2, payload: {} }
+    const paymentHeader = Buffer.from(JSON.stringify(fakePayload)).toString('base64')
+
+    vi.mocked(verifyX402Payment).mockResolvedValue({ valid: true, payer: '0xAGENT' })
+    vi.mocked(settleX402Payment).mockResolvedValue({ success: true, transaction: '0xTX', payer: '0xAGENT' })
+
+    const headers = new Headers({ 'X-PAYMENT': paymentHeader })
+    const result = await authenticateHybrid(headers, endpoint)
+
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.method).toBe('x402')
+      expect((result as { ok: true; method: 'x402'; x402: { payer: string } }).x402.payer).toBe('0xAGENT')
+    }
+  })
+
+  it('returns 402 with PAYMENT-REQUIRED header when no auth provided', async () => {
+    const headers = new Headers()
+    const result = await authenticateHybrid(headers, endpoint)
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error.status).toBe(402)
+      expect(result.error.headers.get('PAYMENT-REQUIRED')).toBeTruthy()
+    }
+  })
+
+  it('returns 402 when x402 verification fails', async () => {
+    const fakePayload = { x402Version: 2, payload: {} }
+    const paymentHeader = Buffer.from(JSON.stringify(fakePayload)).toString('base64')
+
+    vi.mocked(verifyX402Payment).mockResolvedValue({ valid: false, error: 'bad sig' })
+
+    const headers = new Headers({ 'X-PAYMENT': paymentHeader })
+    const result = await authenticateHybrid(headers, endpoint)
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error.status).toBe(402)
+    }
+  })
+
+  it('returns 402 when x402 settlement fails', async () => {
+    const fakePayload = { x402Version: 2, payload: {} }
+    const paymentHeader = Buffer.from(JSON.stringify(fakePayload)).toString('base64')
+
+    vi.mocked(verifyX402Payment).mockResolvedValue({ valid: true, payer: '0xAGENT' })
+    vi.mocked(settleX402Payment).mockResolvedValue({ success: false, error: 'no funds' })
+
+    const headers = new Headers({ 'X-PAYMENT': paymentHeader })
+    const result = await authenticateHybrid(headers, endpoint)
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error.status).toBe(402)
+    }
+  })
+})
+
+describe('buildHybridHeaders', () => {
+  it('returns rate limit headers for API key auth', () => {
+    const h = buildHybridHeaders({
+      ok: true,
+      method: 'api-key',
+      keyId: 'k1',
+      rateLimit: { limited: false, remaining: 99, limit: 100, resetAt: '2026-02-17T00:00:00.000Z' },
+    })
+    expect(h['X-RateLimit-Limit']).toBe('100')
+  })
+
+  it('returns payment headers for x402 auth', () => {
+    const h = buildHybridHeaders({
+      ok: true,
+      method: 'x402',
+      x402: { payer: '0xAGENT', transaction: '0xTX', authMethod: 'x402' },
+    })
+    expect(h['X-Payment-Method']).toBe('x402')
+    expect(h['X-Payment-Tx']).toBe('0xTX')
+  })
+})

--- a/src/lib/x402/__tests__/payment-required.test.ts
+++ b/src/lib/x402/__tests__/payment-required.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Mock config so tests are deterministic
+vi.mock('../config', () => ({
+  x402Config: {
+    payTo: '0xTEST_WALLET',
+    network: 'eip155:42220',
+    assetAddress: '0xUSDC_ADDRESS',
+    assetName: 'USD Coin',
+    baseUrl: 'https://denscope.vercel.app',
+    facilitatorUrl: 'https://facilitator.ultravioletadao.xyz',
+    pricing: { score: 0.001, signals: 0.0005 },
+  },
+}))
+
+import { createPaymentRequired } from '../payment-required'
+
+describe('createPaymentRequired', () => {
+  it('generates valid 402 body for score endpoint', () => {
+    const { body, header } = createPaymentRequired({
+      resourceUrl: 'https://denscope.vercel.app/api/v1/agent/42220/5/score',
+      description: 'Trust score query',
+      priceKey: 'score',
+    })
+
+    expect(body.x402Version).toBe(2)
+    expect(body.accepts).toHaveLength(1)
+    expect(body.accepts[0].scheme).toBe('exact')
+    expect(body.accepts[0].network).toBe('eip155:42220')
+    expect(body.accepts[0].payTo).toBe('0xTEST_WALLET')
+    expect(body.accepts[0].asset).toBe('0xUSDC_ADDRESS')
+    // $0.001 * 1_000_000 = 1000 micro-USDC
+    expect(body.accepts[0].amount).toBe('1000')
+    expect(typeof body.accepts[0].amount).toBe('string')
+    expect(body.accepts[0].extra.assetTransferMethod).toBe('eip3009')
+    expect(body.resource.mimeType).toBe('application/json')
+    expect(header.length).toBeGreaterThan(0)
+  })
+
+  it('generates correct amount for signals pricing', () => {
+    const { body } = createPaymentRequired({
+      resourceUrl: 'https://denscope.vercel.app/api/v1/agent/42220/5/signals',
+      description: 'Signals query',
+      priceKey: 'signals',
+    })
+
+    // $0.0005 * 1_000_000 = 500 micro-USDC
+    expect(body.accepts[0].amount).toBe('500')
+  })
+
+  it('amount is always a string (pitfall #4)', () => {
+    const { body } = createPaymentRequired({
+      resourceUrl: 'https://example.com/test',
+      description: 'Test',
+      priceKey: 'score',
+    })
+    expect(typeof body.accepts[0].amount).toBe('string')
+  })
+
+  it('header decodes back to the body', () => {
+    const { body, header } = createPaymentRequired({
+      resourceUrl: 'https://denscope.vercel.app/api/v1/agent/42220/5/score',
+      description: 'Trust score',
+      priceKey: 'score',
+    })
+    const decoded = JSON.parse(Buffer.from(header, 'base64').toString('utf-8'))
+    expect(decoded).toEqual(body)
+  })
+
+  it('falls back to $0.001 for unknown price key', () => {
+    const { body } = createPaymentRequired({
+      resourceUrl: 'https://example.com/test',
+      description: 'Test',
+      priceKey: 'nonexistent',
+    })
+    expect(body.accepts[0].amount).toBe('1000')
+  })
+})

--- a/src/lib/x402/config.ts
+++ b/src/lib/x402/config.ts
@@ -1,0 +1,36 @@
+/** x402 server config — reads from env vars with Celo mainnet defaults */
+
+export const x402Config = {
+  /** Wallet that receives USDC payments */
+  payTo: process.env.X402_PAY_TO ?? '',
+
+  /** Blockchain network (CAIP-2 format) — Celo mainnet by default */
+  network: process.env.X402_NETWORK ?? 'eip155:42220',
+
+  /** USDC contract address on the target chain */
+  assetAddress:
+    process.env.X402_ASSET_ADDRESS ??
+    '0xcebA9300f2b948710d2653dD7B07f33A8B32118C', // Celo mainnet USDC
+
+  /** Token name for EIP-712 domain */
+  assetName: process.env.X402_ASSET_NAME ?? 'USD Coin',
+
+  /** Public base URL for resource field */
+  baseUrl: process.env.X402_BASE_URL ?? 'https://denscope.vercel.app',
+
+  /** UltravioletaDAO facilitator URL */
+  facilitatorUrl:
+    process.env.X402_FACILITATOR_URL ??
+    'https://facilitator.ultravioletadao.xyz',
+
+  /** Per-endpoint pricing in USD */
+  pricing: {
+    score: parseFloat(process.env.X402_PRICE_SCORE ?? '0.001'),
+    signals: parseFloat(process.env.X402_PRICE_SIGNALS ?? '0.0005'),
+  } as Record<string, number>,
+}
+
+/** Whether x402 is configured (payTo must be set) */
+export function isX402Enabled(): boolean {
+  return x402Config.payTo.length > 0
+}

--- a/src/lib/x402/facilitator.ts
+++ b/src/lib/x402/facilitator.ts
@@ -1,0 +1,105 @@
+import type { PaymentRequirement, X402VerifyResult, X402SettleResult } from './types'
+import { x402Config } from './config'
+
+/**
+ * Decode the base64 X-PAYMENT header into a parsed payload.
+ * Throws on invalid base64 or JSON.
+ */
+function decodePaymentHeader(paymentHeader: string): unknown {
+  return JSON.parse(Buffer.from(paymentHeader, 'base64').toString('utf-8'))
+}
+
+/**
+ * Verify an EIP-712 signature with the facilitator (read-only, no funds move).
+ * IMPORTANT: This only validates — you MUST call settleX402Payment() after.
+ */
+export async function verifyX402Payment(
+  paymentHeader: string,
+  paymentRequirements: PaymentRequirement,
+): Promise<X402VerifyResult> {
+  try {
+    const paymentPayload = decodePaymentHeader(paymentHeader)
+
+    const res = await fetch(`${x402Config.facilitatorUrl}/verify`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        x402Version: 2,
+        paymentPayload,
+        paymentRequirements,
+      }),
+      signal: AbortSignal.timeout(30_000),
+    })
+
+    if (!res.ok) {
+      const text = await res.text().catch(() => '')
+      return { valid: false, error: `Facilitator returned ${res.status}: ${text}` }
+    }
+
+    const result = (await res.json()) as Record<string, unknown>
+
+    // Facilitator returns "isValid" (not "valid") and "invalidReason" (not "error")
+    if (result.isValid) {
+      return {
+        valid: true,
+        payer: result.payer as string,
+        network: result.network as string,
+      }
+    }
+
+    return {
+      valid: false,
+      error: (result.invalidReason as string) || 'Payment verification failed',
+    }
+  } catch (error) {
+    return { valid: false, error: `x402 verification error: ${error}` }
+  }
+}
+
+/**
+ * Settle the payment on-chain via the facilitator.
+ * Calls transferWithAuthorization (EIP-3009) — moves real USDC.
+ * MUST be called AFTER verifyX402Payment() succeeds.
+ */
+export async function settleX402Payment(
+  paymentHeader: string,
+  paymentRequirements: PaymentRequirement,
+): Promise<X402SettleResult> {
+  try {
+    const paymentPayload = decodePaymentHeader(paymentHeader)
+
+    const res = await fetch(`${x402Config.facilitatorUrl}/settle`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        x402Version: 2,
+        paymentPayload,
+        paymentRequirements,
+      }),
+      signal: AbortSignal.timeout(30_000),
+    })
+
+    if (!res.ok) {
+      const text = await res.text().catch(() => '')
+      return { success: false, error: `Facilitator settle returned ${res.status}: ${text}` }
+    }
+
+    const result = (await res.json()) as Record<string, unknown>
+
+    if (result.success) {
+      return {
+        success: true,
+        transaction: result.transaction as string,
+        network: result.network as string,
+        payer: result.payer as string,
+      }
+    }
+
+    return {
+      success: false,
+      error: (result.errorReason as string) || 'Settlement failed',
+    }
+  } catch (error) {
+    return { success: false, error: `x402 settlement error: ${error}` }
+  }
+}

--- a/src/lib/x402/middleware.ts
+++ b/src/lib/x402/middleware.ts
@@ -1,0 +1,135 @@
+import { NextResponse } from 'next/server'
+import type { X402Context } from './types'
+import { x402Config, isX402Enabled } from './config'
+import { createPaymentRequired } from './payment-required'
+import { verifyX402Payment, settleX402Payment } from './facilitator'
+import {
+  extractApiKey,
+  authenticateApiKey,
+  buildRateLimitHeaders,
+  type AuthResult,
+} from '@/lib/api-keys/authenticate'
+import type { RateLimitResult } from '@/lib/api-keys/rate-limit'
+
+/** Unified auth result for routes that accept both API key and x402 */
+export type HybridAuthResult =
+  | { ok: true; method: 'api-key'; keyId: string; rateLimit: RateLimitResult }
+  | { ok: true; method: 'x402'; x402: X402Context }
+  | { ok: false; error: NextResponse }
+
+/**
+ * Hybrid authentication: API key OR x402 payment.
+ *
+ * Priority:
+ * 1. Authorization / X-API-Key header → existing M6 API key auth
+ * 2. X-PAYMENT header → x402 verify + settle via facilitator
+ * 3. Neither → 402 if x402 enabled, 401 otherwise
+ */
+export async function authenticateHybrid(
+  headers: Headers,
+  endpoint: { path: string; priceKey: string; description: string },
+): Promise<HybridAuthResult> {
+  // --- Path 1: API key ---
+  const rawKey = extractApiKey(headers)
+  if (rawKey) {
+    const auth: AuthResult = await authenticateApiKey(headers)
+    if (!auth.ok) return auth
+    return { ok: true, method: 'api-key', keyId: auth.keyId, rateLimit: auth.rateLimit }
+  }
+
+  // --- Path 2: x402 payment ---
+  const paymentHeader = headers.get('X-PAYMENT')
+  if (paymentHeader) {
+    const price = x402Config.pricing[endpoint.priceKey] ?? 0.001
+    const microUnits = Math.round(price * 1_000_000)
+
+    const paymentRequirements = {
+      scheme: 'exact' as const,
+      network: x402Config.network,
+      amount: String(microUnits),
+      asset: x402Config.assetAddress,
+      payTo: x402Config.payTo,
+      maxTimeoutSeconds: 30,
+      extra: {
+        assetTransferMethod: 'eip3009',
+        name: x402Config.assetName,
+        version: '2',
+      },
+    }
+
+    const verifyResult = await verifyX402Payment(paymentHeader, paymentRequirements)
+    if (!verifyResult.valid) {
+      return {
+        ok: false,
+        error: NextResponse.json(
+          { error: 'payment_invalid', message: verifyResult.error ?? 'x402 verification failed' },
+          { status: 402 }
+        ),
+      }
+    }
+
+    // CRITICAL: settle AFTER verify — without this you validate but never collect
+    const settleResult = await settleX402Payment(paymentHeader, paymentRequirements)
+    if (!settleResult.success) {
+      return {
+        ok: false,
+        error: NextResponse.json(
+          { error: 'payment_failed', message: settleResult.error ?? 'x402 settlement failed' },
+          { status: 402 }
+        ),
+      }
+    }
+
+    return {
+      ok: true,
+      method: 'x402',
+      x402: {
+        payer: settleResult.payer ?? verifyResult.payer ?? 'unknown',
+        transaction: settleResult.transaction,
+        authMethod: 'x402',
+      },
+    }
+  }
+
+  // --- Path 3: No auth at all ---
+  if (isX402Enabled()) {
+    const resourceUrl = `${x402Config.baseUrl}${endpoint.path}`
+    const { body, header } = createPaymentRequired({
+      resourceUrl,
+      description: endpoint.description,
+      priceKey: endpoint.priceKey,
+    })
+
+    return {
+      ok: false,
+      error: new NextResponse(JSON.stringify(body), {
+        status: 402,
+        headers: {
+          'Content-Type': 'application/json',
+          'PAYMENT-REQUIRED': header,
+        },
+      }),
+    }
+  }
+
+  // x402 not configured — fall through to standard 401
+  return {
+    ok: false,
+    error: NextResponse.json(
+      { error: 'Missing API key. Provide via Authorization: Bearer <key> or X-API-Key header.' },
+      { status: 401 }
+    ),
+  }
+}
+
+/** Build response headers for a successful hybrid auth result */
+export function buildHybridHeaders(auth: HybridAuthResult & { ok: true }): Record<string, string> {
+  if (auth.method === 'api-key') {
+    return buildRateLimitHeaders(auth.rateLimit)
+  }
+  // x402 payments don't have rate limits — return payment info
+  return {
+    'X-Payment-Method': 'x402',
+    ...(auth.x402.transaction ? { 'X-Payment-Tx': auth.x402.transaction } : {}),
+  }
+}

--- a/src/lib/x402/payment-required.ts
+++ b/src/lib/x402/payment-required.ts
@@ -1,0 +1,49 @@
+import type { PaymentRequiredResponse } from './types'
+import { x402Config } from './config'
+
+interface CreatePaymentRequiredOptions {
+  resourceUrl: string
+  description: string
+  priceKey: string
+}
+
+/**
+ * Build a 402 Payment Required response body + base64-encoded header.
+ * Amount is always serialized as string (pitfall #4 from implementation guide).
+ */
+export function createPaymentRequired(opts: CreatePaymentRequiredOptions): {
+  body: PaymentRequiredResponse
+  header: string
+} {
+  const price = x402Config.pricing[opts.priceKey] ?? 0.001
+  const microUnits = Math.round(price * 1_000_000)
+
+  const body: PaymentRequiredResponse = {
+    x402Version: 2,
+    accepts: [
+      {
+        scheme: 'exact',
+        network: x402Config.network,
+        amount: String(microUnits),
+        asset: x402Config.assetAddress,
+        payTo: x402Config.payTo,
+        maxTimeoutSeconds: 30,
+        extra: {
+          assetTransferMethod: 'eip3009',
+          name: x402Config.assetName,
+          version: '2',
+        },
+      },
+    ],
+    resource: {
+      url: opts.resourceUrl,
+      description: opts.description,
+      mimeType: 'application/json',
+    },
+    error: 'missing payment header',
+  }
+
+  const header = Buffer.from(JSON.stringify(body)).toString('base64')
+
+  return { body, header }
+}

--- a/src/lib/x402/payments.ts
+++ b/src/lib/x402/payments.ts
@@ -1,0 +1,30 @@
+import { supabaseAdmin } from '@/lib/supabase/admin'
+import type { X402Context } from './types'
+import { x402Config } from './config'
+
+/**
+ * Record a successful x402 payment in the audit trail.
+ * Called after settlement succeeds — fire-and-forget (non-blocking).
+ */
+export async function recordX402Payment(params: {
+  chainId: number
+  agentId: number
+  endpoint: string
+  x402: X402Context
+  priceKey: string
+}): Promise<void> {
+  const price = x402Config.pricing[params.priceKey] ?? 0.001
+  const amountMicro = Math.round(price * 1_000_000)
+
+  await supabaseAdmin.from('x402_payments').insert({
+    chain_id: params.chainId,
+    agent_id: params.agentId,
+    endpoint: params.endpoint,
+    payer_address: params.x402.payer,
+    amount_micro: amountMicro,
+    tx_hash: params.x402.transaction ?? null,
+    facilitator: 'ultravioletadao',
+    network: x402Config.network,
+    stablecoin: 'USDC',
+  })
+}

--- a/src/lib/x402/types.ts
+++ b/src/lib/x402/types.ts
@@ -1,0 +1,51 @@
+/** x402 v2 wire protocol types — adapted from docs/x402-implementation-guide.md */
+
+/** Payment requirement sent in the 402 response */
+export interface PaymentRequirement {
+  scheme: string
+  network: string
+  amount: string
+  asset: string
+  payTo: string
+  maxTimeoutSeconds: number
+  extra: Record<string, unknown>
+}
+
+/** Resource metadata in the 402 response */
+export interface ResourceInfo {
+  url: string
+  description: string
+  mimeType: string
+}
+
+/** Full 402 response body */
+export interface PaymentRequiredResponse {
+  x402Version: number
+  accepts: PaymentRequirement[]
+  resource: ResourceInfo
+  error: string
+}
+
+/** Result from facilitator /verify */
+export interface X402VerifyResult {
+  valid: boolean
+  payer?: string
+  network?: string
+  error?: string
+}
+
+/** Result from facilitator /settle */
+export interface X402SettleResult {
+  success: boolean
+  transaction?: string
+  network?: string
+  payer?: string
+  error?: string
+}
+
+/** Context attached to request after successful x402 payment */
+export interface X402Context {
+  payer: string
+  transaction?: string
+  authMethod: 'x402'
+}

--- a/supabase/migrations/20260216050000_m7_x402_payments.sql
+++ b/supabase/migrations/20260216050000_m7_x402_payments.sql
@@ -1,0 +1,38 @@
+-- M7: x402 Trust Oracle — payment audit trail
+-- Append-only, immutable. No UPDATEs, no DELETEs.
+
+CREATE TABLE x402_payments (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  chain_id INT NOT NULL,
+  agent_id INT NOT NULL,
+  endpoint TEXT NOT NULL,
+  payer_address TEXT NOT NULL,
+  amount_micro INT NOT NULL,
+  tx_hash TEXT,
+  facilitator TEXT NOT NULL,
+  settled_at TIMESTAMPTZ DEFAULT NOW(),
+  network TEXT NOT NULL,
+  stablecoin TEXT DEFAULT 'USDC'
+);
+
+-- Revenue analytics: recent payments first
+CREATE INDEX idx_x402_payments_settled ON x402_payments (settled_at DESC);
+
+-- Payer lookup
+CREATE INDEX idx_x402_payments_payer ON x402_payments (payer_address);
+
+-- Per-agent revenue queries
+CREATE INDEX idx_x402_payments_agent ON x402_payments (chain_id, agent_id);
+
+-- RLS: service_role can write, owners can read their claimed agents' payments
+ALTER TABLE x402_payments ENABLE ROW LEVEL SECURITY;
+
+-- Anon/public cannot access
+CREATE POLICY "x402_payments_no_anon"
+  ON x402_payments FOR SELECT
+  USING (false);
+
+-- Service role bypasses RLS by default, but explicit policy for clarity
+CREATE POLICY "x402_payments_service_insert"
+  ON x402_payments FOR INSERT
+  WITH CHECK (true);


### PR DESCRIPTION
## Summary
- x402 micropayment support on `/score` ($0.001) and `/signals` ($0.0005) endpoints
- Hybrid auth: API key OR x402 payment OR 402 response — no regressions on existing M6 auth
- UltravioletaDAO facilitator (Celo mainnet USDC, EIP-3009 off-chain signatures)
- `x402_payments` Supabase table for revenue audit trail (append-only, RLS)
- Public API docs updated with x402 flow, pricing, and 402 error code
- 22 new tests (144 total), build clean

## Files
- `src/lib/x402/` — types, config, payment-required, facilitator, middleware, payments (6 files)
- `src/lib/x402/__tests__/` — config, payment-required, facilitator, middleware (4 test files)
- `supabase/migrations/20260216050000_m7_x402_payments.sql`
- `src/app/api/v1/agent/[chain]/[id]/score/route.ts` — switched to hybrid auth
- `src/app/api/v1/agent/[chain]/[id]/signals/route.ts` — switched to hybrid auth
- `src/app/docs/api/page.tsx` — x402 docs section
- `.env.example` — x402 env vars

## Test plan
- [x] `pnpm build` passes
- [x] 144/144 tests pass (29 files)
- [ ] Deploy to Vercel, set `X402_PAY_TO` env var
- [ ] Apply migration: `supabase db push` or paste SQL in Supabase dashboard
- [ ] Verify existing API key auth still works (no regression)
- [ ] Verify 402 response when calling /score without auth and X402_PAY_TO is set

Closes #68, #69, #70, #71, #72

Wolfcito 🐾 @akawolfcito