### PR TITLE
feat: agent registration UI in Console

### DIFF
--- a/src/app/api/ipfs/upload/route.ts
+++ b/src/app/api/ipfs/upload/route.ts
@@ -1,0 +1,89 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getChain } from '@/config/chains'
+
+export async function POST(req: NextRequest) {
+  try {
+    const jwt = process.env.PINATA_JWT
+    if (!jwt) {
+      return NextResponse.json(
+        { error: 'IPFS upload not configured' },
+        { status: 503 }
+      )
+    }
+
+    const { name, description, image, chainId } = await req.json()
+
+    if (!name || !description || !chainId) {
+      return NextResponse.json(
+        { error: 'Missing required fields: name, description, chainId' },
+        { status: 400 }
+      )
+    }
+
+    const chain = getChain(chainId)
+    if (!chain) {
+      return NextResponse.json(
+        { error: 'Unsupported chain' },
+        { status: 400 }
+      )
+    }
+
+    const metadata = {
+      type: 'https://eips.ethereum.org/EIPS/eip-8004#registration-v1',
+      name,
+      description,
+      ...(image ? { image } : {}),
+      services: [],
+      x402Support: false,
+      active: true,
+      registrations: [
+        {
+          agentId: 0,
+          agentRegistry: `eip155:${chain.id}:${chain.contracts.identity}`,
+        },
+      ],
+      supportedTrust: ['reputation'],
+    }
+
+    const blob = new Blob([JSON.stringify(metadata)], {
+      type: 'application/json',
+    })
+    const file = new File([blob], `erc8004-agent-${name}.json`, {
+      type: 'application/json',
+    })
+
+    const formData = new FormData()
+    formData.append('file', file)
+    formData.append('network', 'public')
+
+    const pinataRes = await fetch(
+      'https://uploads.pinata.cloud/v3/files',
+      {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${jwt}`,
+        },
+        body: formData,
+      }
+    )
+
+    if (!pinataRes.ok) {
+      const err = await pinataRes.text()
+      console.error('Pinata error:', err)
+      return NextResponse.json(
+        { error: 'IPFS upload failed' },
+        { status: 502 }
+      )
+    }
+
+    const { data } = await pinataRes.json()
+
+    return NextResponse.json({ uri: `ipfs://${data.cid}` })
+  } catch (err) {
+    console.error('IPFS upload error:', err)
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    )
+  }
+}

--- a/src/app/console/page.tsx
+++ b/src/app/console/page.tsx
@@ -1,4 +1,5 @@
 import { ConsoleGuard } from '@/components/console/ConsoleGuard'
+import { RegisterAgentPanel } from '@/components/console/RegisterAgentPanel'
 import { ClaimedAgentsList } from '@/components/console/ClaimedAgentsList'
 import { IncidentTimeline } from '@/components/console/IncidentTimeline'
 import { AlertsPanel } from '@/components/console/AlertsPanel'
@@ -24,6 +25,16 @@ export default function ConsolePage() {
           <p className="mt-1 text-sm text-text-secondary">
             Your claimed agents and dashboard.
           </p>
+
+          <div className="mt-8">
+            <h2 className="text-xs text-text-muted uppercase tracking-wider font-mono mb-1">
+              Register Agent
+            </h2>
+            <p className="text-xs text-text-muted mb-4">
+              Deploy a new ERC-8004 agent on-chain with metadata stored on IPFS.
+            </p>
+            <RegisterAgentPanel />
+          </div>
 
           <div className="mt-8">
             <h2 className="text-xs text-text-muted uppercase tracking-wider font-mono mb-1">

--- a/src/components/console/RegisterAgentPanel.tsx
+++ b/src/components/console/RegisterAgentPanel.tsx
@@ -1,0 +1,241 @@
+'use client'
+
+import { useState } from 'react'
+import {
+  useAccount,
+  useChainId,
+  useSwitchChain,
+  useWriteContract,
+  useWaitForTransactionReceipt,
+} from 'wagmi'
+import Link from 'next/link'
+import { decodeEventLog } from 'viem'
+import { chains } from '@/config/chains'
+import { identityRegistryAbi } from '@/config/contracts'
+import { uploadAgentMetadata } from '@/lib/ipfs/upload'
+
+type Status = 'idle' | 'uploading' | 'signing' | 'confirming' | 'success' | 'error'
+
+export function RegisterAgentPanel() {
+  const { address } = useAccount()
+  const currentChainId = useChainId()
+  const { switchChainAsync } = useSwitchChain()
+  const { writeContractAsync } = useWriteContract()
+  const [txHash, setTxHash] = useState<`0x${string}` | undefined>()
+
+  const [name, setName] = useState('')
+  const [description, setDescription] = useState('')
+  const [image, setImage] = useState('')
+  const [selectedChainId, setSelectedChainId] = useState(chains[0].id)
+  const [status, setStatus] = useState<Status>('idle')
+  const [errorMsg, setErrorMsg] = useState('')
+  const [agentId, setAgentId] = useState<string | null>(null)
+
+  const { isLoading: isConfirming } = useWaitForTransactionReceipt({
+    hash: txHash,
+    query: {
+      enabled: !!txHash,
+      select(receipt) {
+        for (const log of receipt.logs) {
+          try {
+            const decoded = decodeEventLog({
+              abi: identityRegistryAbi,
+              data: log.data,
+              topics: log.topics,
+            })
+            if (decoded.eventName === 'Registered') {
+              const id = (decoded.args as { agentId: bigint }).agentId.toString()
+              setAgentId(id)
+              setStatus('success')
+              return receipt
+            }
+          } catch {
+            // not our event, skip
+          }
+        }
+        setStatus('success')
+        return receipt
+      },
+    },
+  })
+
+  const selectedChain = chains.find((c) => c.id === selectedChainId)!
+
+  async function handleRegister() {
+    if (!address || !name.trim() || !description.trim()) return
+
+    setErrorMsg('')
+    setAgentId(null)
+    setTxHash(undefined)
+
+    try {
+      // Upload metadata to IPFS
+      setStatus('uploading')
+      const uri = await uploadAgentMetadata({
+        name: name.trim(),
+        description: description.trim(),
+        image: image.trim() || undefined,
+        chainId: selectedChainId,
+      })
+
+      // Switch chain if needed
+      if (currentChainId !== selectedChainId) {
+        await switchChainAsync({ chainId: selectedChainId })
+      }
+
+      // Send register transaction
+      setStatus('signing')
+      const hash = await writeContractAsync({
+        address: selectedChain.contracts.identity,
+        abi: identityRegistryAbi,
+        functionName: 'register',
+        args: [uri],
+        chainId: selectedChainId,
+      })
+
+      setTxHash(hash)
+      setStatus('confirming')
+    } catch (err) {
+      console.error('Registration error:', err)
+      setStatus('error')
+      setErrorMsg(
+        err instanceof Error ? err.message : 'Registration failed'
+      )
+    }
+  }
+
+  const isWorking = status === 'uploading' || status === 'signing' || status === 'confirming' || isConfirming
+
+  return (
+    <div className="bg-surface border border-border p-6 space-y-4">
+      <h2 className="font-display text-lg font-bold uppercase tracking-wider text-text-primary">
+        Register Agent
+      </h2>
+      <p className="text-xs text-text-muted font-mono">
+        Register a new ERC-8004 agent on-chain. Metadata is uploaded to IPFS.
+      </p>
+
+      {status === 'success' ? (
+        <div className="bg-background border border-accent p-4 space-y-2">
+          <p className="text-sm font-mono text-accent font-bold">
+            Agent registered successfully!
+          </p>
+          {agentId && (
+            <Link
+              href={`/agent/${selectedChainId}/${agentId}`}
+              className="inline-block text-xs font-mono text-accent hover:underline"
+            >
+              View agent #{agentId} on {selectedChain.name}
+            </Link>
+          )}
+          <div>
+            <button
+              onClick={() => {
+                setStatus('idle')
+                setName('')
+                setDescription('')
+                setImage('')
+                setAgentId(null)
+                setTxHash(undefined)
+              }}
+              className="text-xs font-mono text-text-muted hover:underline mt-2"
+            >
+              Register another
+            </button>
+          </div>
+        </div>
+      ) : (
+        <>
+          <div className="space-y-3">
+            <div>
+              <label className="text-[10px] text-text-muted font-mono uppercase tracking-wider block mb-1">
+                Name *
+              </label>
+              <input
+                type="text"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="My Agent"
+                disabled={isWorking}
+                className="w-full bg-background border border-border px-3 py-1.5 text-xs font-mono text-text-primary disabled:opacity-50"
+              />
+            </div>
+            <div>
+              <label className="text-[10px] text-text-muted font-mono uppercase tracking-wider block mb-1">
+                Description *
+              </label>
+              <textarea
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                placeholder="What does this agent do?"
+                rows={3}
+                disabled={isWorking}
+                className="w-full bg-background border border-border px-3 py-1.5 text-xs font-mono text-text-primary resize-none disabled:opacity-50"
+              />
+            </div>
+            <div>
+              <label className="text-[10px] text-text-muted font-mono uppercase tracking-wider block mb-1">
+                Image URL
+              </label>
+              <input
+                type="text"
+                value={image}
+                onChange={(e) => setImage(e.target.value)}
+                placeholder="https://..."
+                disabled={isWorking}
+                className="w-full bg-background border border-border px-3 py-1.5 text-xs font-mono text-text-primary disabled:opacity-50"
+              />
+            </div>
+            <div>
+              <label className="text-[10px] text-text-muted font-mono uppercase tracking-wider block mb-1">
+                Chain
+              </label>
+              <select
+                value={selectedChainId}
+                onChange={(e) => setSelectedChainId(Number(e.target.value))}
+                disabled={isWorking}
+                className="w-full bg-background border border-border px-3 py-1.5 text-xs font-mono text-text-primary disabled:opacity-50"
+              >
+                {chains.map((c) => (
+                  <option key={c.id} value={c.id}>
+                    {c.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+
+          {status === 'error' && (
+            <p className="text-xs font-mono text-critical">{errorMsg}</p>
+          )}
+
+          <div className="flex items-center gap-3">
+            <button
+              onClick={handleRegister}
+              disabled={isWorking || !name.trim() || !description.trim()}
+              className="bg-accent text-background px-4 py-1.5 text-xs font-mono font-bold hover:opacity-90 disabled:opacity-50"
+            >
+              {status === 'uploading'
+                ? 'Uploading to IPFS...'
+                : status === 'signing'
+                  ? 'Confirm in wallet...'
+                  : status === 'confirming'
+                    ? 'Confirming tx...'
+                    : 'Register'}
+            </button>
+            {txHash && (
+              <a
+                href={`${selectedChain.explorer}/tx/${txHash}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-[10px] font-mono text-text-muted hover:underline"
+              >
+                View tx
+              </a>
+            )}
+          </div>
+        </>
+      )}
+    </div>
+  )
+}

--- a/src/config/contracts.ts
+++ b/src/config/contracts.ts
@@ -41,6 +41,13 @@ export const identityRegistryAbi = [
     inputs: [{ name: 'tokenId', type: 'uint256' }],
     outputs: [{ name: '', type: 'address' }],
   },
+  {
+    type: 'function',
+    name: 'register',
+    stateMutability: 'nonpayable',
+    inputs: [{ name: 'agentURI', type: 'string' }],
+    outputs: [{ name: 'tokenId', type: 'uint256' }],
+  },
 ] as const
 
 export const reputationRegistryAbi = [

--- a/src/lib/ipfs/upload.ts
+++ b/src/lib/ipfs/upload.ts
@@ -1,0 +1,20 @@
+export async function uploadAgentMetadata(metadata: {
+  name: string
+  description: string
+  image?: string
+  chainId: number
+}): Promise<string> {
+  const res = await fetch('/api/ipfs/upload', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(metadata),
+  })
+
+  if (!res.ok) {
+    const data = await res.json().catch(() => ({ error: 'Upload failed' }))
+    throw new Error(data.error ?? 'IPFS upload failed')
+  }
+
+  const { uri } = await res.json()
+  return uri
+}


### PR DESCRIPTION
## Summary
- **RegisterAgentPanel** — form + tx state machine to register ERC-8004 agents from the browser
- **IPFS upload API route** — server-side Pinata V3 proxy (`/api/ipfs/upload`), keeps JWT secret
- **ABI update** — `register(agentURI)` added to identity registry ABI
- **Console page** — registration panel as first section above Claimed Agents

Enables the self-service loop: **Register → Claim → Console → API Key → SDK**

## Env var required
`PINATA_JWT` — Pinata API key with **Files → Write** permission (V3). Server-only.

## Test plan
- [x] `pnpm build` — zero errors
- [x] `pnpm test` — 144/144 pass
- [ ] Manual test on Celo Sepolia: connect wallet → fill form → register → verify on-chain
- [ ] Visit `/agent/11142220/{newId}` → agent page loads
- [ ] Claim new agent → appears in Claimed Agents

Wolfcito 🐾 @akawolfcito