### PR TITLE
fix: mobile UX — Certificate Station close + responsive Header

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useMemo, useEffect } from 'react'
+import { useState, useMemo, useEffect, useRef, useCallback } from 'react'
 import { LiveFeed } from '@/components/feed/LiveFeed'
 import { FeedFiltersBar } from '@/components/feed/FeedFilters'
 import { FeedHint } from '@/components/feed/FeedHint'
@@ -33,6 +33,7 @@ function useLayout(): Layout {
 export default function FeedPage() {
   const [selectedAgent, setSelectedAgent] = useState<string | null>(null)
   const [hintDismissed, setHintDismissed] = useState(false)
+  const dismissedRef = useRef(false)
   const events = useEventStore((s) => s.events)
   const agents = useAgentStore((s) => s.agents)
   const agentCount = agents.size
@@ -43,10 +44,21 @@ export default function FeedPage() {
   // Auto-select first agent when events arrive and no selection yet
   useEffect(() => {
     if (selectedAgent) return
+    if (dismissedRef.current) return
     if (events.length === 0) return
     const first = events[0]
     setSelectedAgent(`${first.chainId}:${first.agentId}`)
   }, [events, selectedAgent])
+
+  const handleAgentClick = useCallback((key: string) => {
+    dismissedRef.current = false
+    setSelectedAgent(key)
+  }, [])
+
+  const handleStationClose = useCallback(() => {
+    dismissedRef.current = true
+    setSelectedAgent(null)
+  }, [])
 
   const filteredCount = useMemo(() => {
     const hasFilter = filters.kinds.size > 0 || filters.chainId !== null || filters.agentId !== ''
@@ -99,7 +111,7 @@ export default function FeedPage() {
       <div className="flex flex-1 overflow-hidden">
         <div className="flex-1 overflow-hidden">
           <LiveFeed
-            onAgentClick={setSelectedAgent}
+            onAgentClick={handleAgentClick}
             onFirstHover={() => setHintDismissed(true)}
             filters={filters}
             selectedAgentKey={selectedAgent}
@@ -108,7 +120,7 @@ export default function FeedPage() {
         <CertificateStation
           agentKey={selectedAgent}
           layout={layout}
-          onClose={() => setSelectedAgent(null)}
+          onClose={handleStationClose}
         />
       </div>
 

--- a/src/components/feed/CertificateStation.tsx
+++ b/src/components/feed/CertificateStation.tsx
@@ -206,7 +206,11 @@ export function CertificateStation({ agentKey, layout, onClose }: CertificateSta
   }, [agent, agentKey, cacheMetadata])
 
   function handleClose() {
-    setIsOpen(false)
+    if (layout === 'sheet') {
+      onClose?.()
+    } else {
+      setIsOpen(false)
+    }
   }
 
   function handleOpen() {

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react'
 import Image from 'next/image'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
+import { motion, AnimatePresence } from 'framer-motion'
 import { SearchModal } from '@/components/search/SearchModal'
 import { ConnectButton } from '@/components/auth/ConnectButton'
 import { IncidentBadge } from '@/components/console/IncidentBadge'
@@ -18,6 +19,12 @@ const navItems = [
 export function Header() {
   const pathname = usePathname()
   const [searchOpen, setSearchOpen] = useState(false)
+  const [menuOpen, setMenuOpen] = useState(false)
+
+  // Close mobile menu on route change
+  useEffect(() => {
+    setMenuOpen(false)
+  }, [pathname])
 
   useEffect(() => {
     function onKeyDown(e: KeyboardEvent) {
@@ -31,10 +38,8 @@ export function Header() {
   }, [])
 
   return (
-    <header
-      className="border-b border-border bg-bg px-6 py-3"
-    >
-      <div className="flex items-center justify-between">
+    <header className="border-b border-border bg-bg">
+      <div className="flex items-center justify-between px-6 py-3">
         {/* Left: Logo + Nav */}
         <div className="flex items-center gap-8">
           {/* Logo */}
@@ -51,8 +56,8 @@ export function Header() {
             </span>
           </Link>
 
-          {/* Navigation */}
-          <nav className="flex gap-6">
+          {/* Navigation — desktop only */}
+          <nav className="hidden md:flex gap-6">
             {navItems.map((item) => {
               const isActive = pathname === item.href
 
@@ -82,26 +87,126 @@ export function Header() {
           </nav>
         </div>
 
-        {/* Right: Search + Status */}
+        {/* Right: Search + Wallet + Status (desktop) / Wallet + Hamburger (mobile) */}
         <div className="flex items-center gap-4">
+          {/* Search — desktop only */}
           <button
             onClick={() => setSearchOpen(true)}
-            className="flex items-center gap-2 border border-border bg-surface px-3 py-1 text-xs font-mono text-text-muted transition-colors hover:text-text-secondary"
+            className="hidden md:flex items-center gap-2 border border-border bg-surface px-3 py-1 text-xs font-mono text-text-muted transition-colors hover:text-text-secondary"
           >
             Search
             <kbd className="border border-border px-1 py-0.5 text-[10px]">
               {'\u2318'}K
             </kbd>
           </button>
+
           <ConnectButton />
-          <div className="flex items-center gap-2">
+
+          {/* Status — desktop only */}
+          <div className="hidden md:flex items-center gap-2">
             <span className="h-1.5 w-1.5 rounded-full bg-success" />
             <span className="text-[10px] uppercase tracking-widest text-text-muted">
               Mainnet
             </span>
           </div>
+
+          {/* Hamburger — mobile only */}
+          <button
+            onClick={() => setMenuOpen((prev) => !prev)}
+            className="md:hidden flex items-center justify-center w-8 h-8 text-text-muted hover:text-text-primary transition-colors"
+            aria-label={menuOpen ? 'Close menu' : 'Open menu'}
+          >
+            <svg
+              width="18"
+              height="18"
+              viewBox="0 0 18 18"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+            >
+              {menuOpen ? (
+                <>
+                  <line x1="4" y1="4" x2="14" y2="14" />
+                  <line x1="14" y1="4" x2="4" y2="14" />
+                </>
+              ) : (
+                <>
+                  <line x1="3" y1="5" x2="15" y2="5" />
+                  <line x1="3" y1="9" x2="15" y2="9" />
+                  <line x1="3" y1="13" x2="15" y2="13" />
+                </>
+              )}
+            </svg>
+          </button>
         </div>
       </div>
+
+      {/* Mobile dropdown menu */}
+      <AnimatePresence>
+        {menuOpen && (
+          <motion.div
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: 'auto', opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={{ duration: 0.2 }}
+            className="md:hidden overflow-hidden border-t border-border bg-bg"
+          >
+            <div className="px-6 py-3">
+              {/* Search */}
+              <button
+                onClick={() => {
+                  setMenuOpen(false)
+                  setSearchOpen(true)
+                }}
+                className="flex w-full items-center gap-2 border border-border bg-surface px-3 py-2.5 text-xs font-mono text-text-muted transition-colors hover:text-text-secondary"
+              >
+                Search
+                <kbd className="ml-auto border border-border px-1 py-0.5 text-[10px]">
+                  {'\u2318'}K
+                </kbd>
+              </button>
+            </div>
+
+            <div className="border-t border-border" />
+
+            {/* Nav items */}
+            <nav className="flex flex-col">
+              {navItems.map((item) => {
+                const isActive = pathname === item.href
+
+                return (
+                  <Link
+                    key={item.href}
+                    href={item.href}
+                    onClick={() => setMenuOpen(false)}
+                    className={`flex items-center px-6 py-3 text-xs uppercase tracking-widest transition-colors ${
+                      isActive
+                        ? 'text-text-primary bg-surface'
+                        : 'text-text-muted hover:text-text-secondary hover:bg-surface/50'
+                    }`}
+                  >
+                    {item.label}
+                    {item.href === '/console' && (
+                      <span className="ml-1"><IncidentBadge /></span>
+                    )}
+                  </Link>
+                )
+              })}
+            </nav>
+
+            <div className="border-t border-border" />
+
+            {/* Status */}
+            <div className="flex items-center gap-2 px-6 py-3">
+              <span className="h-1.5 w-1.5 rounded-full bg-success" />
+              <span className="text-[10px] uppercase tracking-widest text-text-muted">
+                Mainnet
+              </span>
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
 
       <SearchModal open={searchOpen} onClose={() => setSearchOpen(false)} />
     </header>


### PR DESCRIPTION
## Summary
- Fix Certificate Station bottom sheet not closing on mobile (X button and backdrop tap were blocked by auto-select useEffect immediately re-selecting an agent)
- Add responsive hamburger menu to Header for mobile viewports (<768px)
- Desktop layout unchanged

## Test plan
- [ ] Mobile (<768px): tap X on bottom sheet → sheet closes, feed visible
- [ ] Mobile: tap backdrop → sheet closes
- [ ] Mobile: drag sheet down → sheet closes
- [ ] Mobile: tap agent row → sheet opens with new agent
- [ ] Mobile: hamburger visible, nav hidden, wallet visible
- [ ] Mobile: tap hamburger → dropdown with nav + search + status
- [ ] Desktop (>=768px): unchanged layout, hamburger hidden
- [ ] `pnpm build` clean, `pnpm test` 153/153

Wolfcito 🐾 @akawolfcito