### PR TITLE
fix: UI/UX polish — mobile layouts, copy feedback, skeletons

### DIFF
--- a/src/app/console/page.tsx
+++ b/src/app/console/page.tsx
@@ -19,7 +19,7 @@ export default function ConsolePage() {
             System / DenScope / Console
           </nav>
 
-          <h1 className="font-display text-3xl font-bold uppercase tracking-wider mt-4 text-text-primary">
+          <h1 className="font-display text-2xl font-bold uppercase tracking-wider mt-4 text-text-primary">
             Owner Console
           </h1>
           <p className="mt-1 text-sm text-text-secondary">

--- a/src/app/docs/api/page.tsx
+++ b/src/app/docs/api/page.tsx
@@ -13,7 +13,7 @@ export default function ApiDocsPage() {
           System / DenScope / API
         </nav>
 
-        <h1 className="font-display text-3xl font-bold uppercase tracking-wider mt-4 text-text-primary">
+        <h1 className="font-display text-2xl font-bold uppercase tracking-wider mt-4 text-text-primary">
           REPUTATION API
         </h1>
         <p className="mt-2 text-sm text-text-secondary max-w-2xl">

--- a/src/components/agent/TrustSnapshot.tsx
+++ b/src/components/agent/TrustSnapshot.tsx
@@ -83,7 +83,7 @@ export function TrustSnapshot({
       <h3 className="text-sm font-mono font-bold text-text-primary mb-4">
         Trust Snapshot
       </h3>
-      <div className="grid grid-cols-5 gap-4">
+      <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-4">
         <MetricCard
           label="Reputation"
           value={reputationValue}

--- a/src/components/console/AlertsPanel.tsx
+++ b/src/components/console/AlertsPanel.tsx
@@ -127,7 +127,20 @@ export function AlertsPanel() {
   }
 
   if (loading) {
-    return <p className="text-xs text-text-muted font-mono">Loading alerts...</p>
+    return (
+      <div className="bg-surface border border-border p-5 space-y-4">
+        <div className="h-3 w-24 bg-border rounded animate-pulse" />
+        {[1, 2, 3].map((i) => (
+          <div key={i} className="flex items-center justify-between py-2 animate-pulse">
+            <div className="space-y-1.5">
+              <div className="h-3 w-28 bg-border rounded" />
+              <div className="h-2.5 w-44 bg-border rounded" />
+            </div>
+            <div className="h-5 w-10 bg-border rounded-full" />
+          </div>
+        ))}
+      </div>
+    )
   }
 
   if (rules.length === 0) {

--- a/src/components/console/ApiKeysPanel.tsx
+++ b/src/components/console/ApiKeysPanel.tsx
@@ -91,7 +91,12 @@ export function ApiKeysPanel() {
             {newKey}
           </code>
           <button
-            onClick={() => { navigator.clipboard.writeText(newKey); setNewKey(null) }}
+            onClick={() => {
+              navigator.clipboard.writeText(newKey)
+              const btn = document.activeElement as HTMLButtonElement
+              if (btn) btn.textContent = 'Copied!'
+              setTimeout(() => setNewKey(null), 800)
+            }}
             className="text-[10px] font-mono text-accent hover:underline"
           >
             Copy &amp; Dismiss

--- a/src/components/console/ClaimedAgentsList.tsx
+++ b/src/components/console/ClaimedAgentsList.tsx
@@ -21,7 +21,17 @@ export function ClaimedAgentsList() {
 
   if (loading) {
     return (
-      <p className="text-xs text-text-muted font-mono">Loading your agents...</p>
+      <div className="space-y-2">
+        {[1, 2].map((i) => (
+          <div key={i} className="animate-pulse bg-surface border border-border p-4 flex items-center justify-between">
+            <div className="flex items-center gap-4">
+              <div className="h-5 w-10 bg-border rounded" />
+              <div className="h-3 w-20 bg-border rounded" />
+            </div>
+            <div className="h-4 w-16 bg-border rounded" />
+          </div>
+        ))}
+      </div>
     )
   }
 

--- a/src/components/feed/FeedFilters.tsx
+++ b/src/components/feed/FeedFilters.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useState, useEffect, useRef } from 'react'
 import type { EventKind } from '@/types/events'
 import type { FeedFilters } from '@/hooks/useFeedFilters'
 import { chains } from '@/config/chains'
@@ -38,6 +39,14 @@ type FeedFiltersBarProps = {
 }
 
 export function FeedFiltersBar({ filters, onChange }: FeedFiltersBarProps) {
+  const [agentInput, setAgentInput] = useState(filters.agentId)
+  const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined)
+
+  // Sync external filter changes back to local input
+  useEffect(() => {
+    setAgentInput(filters.agentId)
+  }, [filters.agentId])
+
   function toggleKind(kind: EventKind) {
     const next = new Set(filters.kinds)
     if (next.has(kind)) {
@@ -53,7 +62,12 @@ export function FeedFiltersBar({ filters, onChange }: FeedFiltersBarProps) {
   }
 
   function setAgent(value: string) {
-    onChange({ ...filters, agentId: value })
+    const cleaned = value.replace(/[^0-9]/g, '')
+    setAgentInput(cleaned)
+    clearTimeout(debounceRef.current)
+    debounceRef.current = setTimeout(() => {
+      onChange({ ...filters, agentId: cleaned })
+    }, 300)
   }
 
   const hasActiveFilters = filters.kinds.size > 0 || filters.chainId !== null || filters.agentId !== ''
@@ -103,8 +117,8 @@ export function FeedFiltersBar({ filters, onChange }: FeedFiltersBarProps) {
           type="text"
           inputMode="numeric"
           placeholder="#"
-          value={filters.agentId}
-          onChange={(e) => setAgent(e.target.value.replace(/[^0-9]/g, ''))}
+          value={agentInput}
+          onChange={(e) => setAgent(e.target.value)}
           className="bg-surface border border-border text-text-primary text-xs font-mono px-2 py-1 w-16 rounded-sm focus:outline-none focus:ring-1 focus:ring-text-primary placeholder:text-text-muted"
         />
       </div>

--- a/src/components/feed/FeedLine.tsx
+++ b/src/components/feed/FeedLine.tsx
@@ -80,53 +80,65 @@ export function FeedLine({ event, isSelected, onClick }: FeedLineProps) {
   return (
     <button
       onClick={onClick}
-      className={`group grid w-full grid-cols-[120px_100px_100px_1fr_120px_auto_auto] items-center gap-0 border-b border-border px-4 py-1.5 text-left font-mono text-sm transition-colors hover:bg-surface-hover cursor-pointer ${
+      className={`group w-full border-b border-border px-4 py-1.5 text-left font-mono text-sm transition-colors hover:bg-surface-hover cursor-pointer ${
         isSelected
           ? 'bg-surface-hover border-l-2 border-l-accent'
           : 'hover:border-l-2 hover:border-l-accent'
       }`}
     >
-      {/* Timestamp */}
-      <span className="shrink-0 text-text-muted text-xs">
-        {formatTime(event.timestamp)}
-      </span>
-
-      {/* Event Type Pill */}
-      <span>
-        <span className={kindPillClass[event.kind] ?? 'status-pill status-pill-neutral'}>
-          {kindLabels[event.kind] ?? event.kind.toUpperCase()}
+      {/* Desktop: full grid */}
+      <div className="hidden md:grid grid-cols-[120px_100px_100px_1fr_120px_auto_auto] items-center gap-0">
+        <span className="shrink-0 text-text-muted text-xs">
+          {formatTime(event.timestamp)}
         </span>
-      </span>
+        <span>
+          <span className={kindPillClass[event.kind] ?? 'status-pill status-pill-neutral'}>
+            {kindLabels[event.kind] ?? event.kind.toUpperCase()}
+          </span>
+        </span>
+        <span className="text-text-secondary text-xs">ERC-8004</span>
+        <span className="truncate text-text-primary text-xs group-hover:text-accent group-hover:underline transition-colors">
+          {formatSummary(event)}
+        </span>
+        <span className="font-mono text-text-muted text-xs">
+          {formatTxHash(event.txHash)}
+        </span>
+        <span
+          role="button"
+          tabIndex={-1}
+          onClick={handleShare}
+          className="opacity-0 group-hover:opacity-100 transition-opacity text-text-muted hover:text-accent px-2"
+        >
+          <ShareIcon />
+        </span>
+        <span className="text-[10px] tracking-wider uppercase border border-border px-2 py-0.5 text-text-muted group-hover:border-accent group-hover:text-accent transition-colors whitespace-nowrap">
+          INSPECT
+        </span>
+      </div>
 
-      {/* Protocol */}
-      <span className="text-text-secondary text-xs">
-        ERC-8004
-      </span>
-
-      {/* Agent Identity */}
-      <span className="truncate text-text-primary text-xs group-hover:text-accent group-hover:underline transition-colors">
-        {formatSummary(event)}
-      </span>
-
-      {/* Tx Hash */}
-      <span className="font-mono text-text-muted text-xs">
-        {formatTxHash(event.txHash)}
-      </span>
-
-      {/* Share Icon */}
-      <span
-        role="button"
-        tabIndex={-1}
-        onClick={handleShare}
-        className="opacity-100 md:opacity-0 md:group-hover:opacity-100 transition-opacity text-text-muted hover:text-accent px-2"
-      >
-        <ShareIcon />
-      </span>
-
-      {/* Inspect CTA */}
-      <span className="text-[10px] tracking-wider uppercase border border-border px-2 py-0.5 text-text-muted group-hover:border-accent group-hover:text-accent transition-colors whitespace-nowrap">
-        INSPECT
-      </span>
+      {/* Mobile: compact 2-row layout */}
+      <div className="md:hidden flex flex-col gap-1">
+        <div className="flex items-center justify-between gap-2">
+          <span className={kindPillClass[event.kind] ?? 'status-pill status-pill-neutral'}>
+            {kindLabels[event.kind] ?? event.kind.toUpperCase()}
+          </span>
+          <span className="truncate flex-1 text-text-primary text-xs group-hover:text-accent transition-colors">
+            {formatSummary(event)}
+          </span>
+          <span
+            role="button"
+            tabIndex={-1}
+            onClick={handleShare}
+            className="text-text-muted hover:text-accent shrink-0"
+          >
+            <ShareIcon />
+          </span>
+        </div>
+        <div className="flex items-center justify-between text-text-muted text-[10px]">
+          <span>{formatTime(event.timestamp)}</span>
+          <span>{formatTxHash(event.txHash)}</span>
+        </div>
+      </div>
     </button>
   )
 }

--- a/src/components/feed/LiveFeed.tsx
+++ b/src/components/feed/LiveFeed.tsx
@@ -33,7 +33,7 @@ export function LiveFeed({ onAgentClick, onFirstHover, filters, selectedAgentKey
       onMouseLeave={() => setPaused(false)}
     >
       {/* Column Headers */}
-      <div className="sticky top-0 z-10 grid grid-cols-[120px_100px_100px_1fr_120px_auto_auto] gap-0 border-b border-border bg-surface px-4 py-2">
+      <div className="sticky top-0 z-10 hidden md:grid grid-cols-[120px_100px_100px_1fr_120px_auto_auto] gap-0 border-b border-border bg-surface px-4 py-2">
         <span className="font-mono text-[10px] text-text-muted uppercase tracking-widest">Timestamp</span>
         <span className="font-mono text-[10px] text-text-muted uppercase tracking-widest">Event Type</span>
         <span className="font-mono text-[10px] text-text-muted uppercase tracking-widest">Protocol</span>

--- a/src/components/layout/StatusBar.tsx
+++ b/src/components/layout/StatusBar.tsx
@@ -1,6 +1,7 @@
 'use client'
 
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
+import { useEventStore } from '@/stores/events'
 
 function formatUptime(seconds: number): string {
   const h = Math.floor(seconds / 3600)
@@ -15,6 +16,10 @@ function formatUptime(seconds: number): string {
 
 export function StatusBar() {
   const [uptime, setUptime] = useState(0)
+  const eventCount = useEventStore((s) => s.events.length)
+  const lastCountRef = useRef(eventCount)
+  const [feedActive, setFeedActive] = useState(false)
+  const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined)
 
   useEffect(() => {
     const interval = setInterval(() => {
@@ -23,16 +28,27 @@ export function StatusBar() {
     return () => clearInterval(interval)
   }, [])
 
+  // Track whether new events arrived recently (within 90s)
+  useEffect(() => {
+    if (eventCount > lastCountRef.current) {
+      setFeedActive(true)
+      clearTimeout(timerRef.current)
+      timerRef.current = setTimeout(() => setFeedActive(false), 90_000)
+    }
+    lastCountRef.current = eventCount
+    return () => clearTimeout(timerRef.current)
+  }, [eventCount])
+
   return (
     <footer className="border-t border-border bg-bg px-6 py-2 font-mono text-xs uppercase tracking-wider text-text-secondary">
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-4">
-          <span>System Uptime: {formatUptime(uptime)}</span>
+          <span>Session: {formatUptime(uptime)}</span>
           <span className="border border-border px-2 py-0.5">v0.1.0</span>
         </div>
         <div className="flex items-center gap-2">
-          <span className="h-1.5 w-1.5 rounded-full bg-success" />
-          <span>Feed Active</span>
+          <span className={`h-1.5 w-1.5 rounded-full ${feedActive ? 'bg-success' : 'bg-warning'}`} />
+          <span>{feedActive ? 'Feed Active' : 'Feed Idle'}</span>
         </div>
       </div>
     </footer>

--- a/src/components/shared/AddressChip.tsx
+++ b/src/components/shared/AddressChip.tsx
@@ -1,21 +1,29 @@
 'use client'
 
+import { useState } from 'react'
 import { getChain } from '@/config/chains'
 
 export function AddressChip({ address, chainId }: { address: string; chainId?: number }) {
+  const [copied, setCopied] = useState(false)
   const truncated = `${address.slice(0, 6)}...${address.slice(-4)}`
   const chain = chainId ? getChain(chainId) : null
   const explorerUrl = chain ? `${chain.explorer}/address/${address}` : null
+
+  function handleCopy() {
+    navigator.clipboard.writeText(address)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 1500)
+  }
 
   return (
     <span className="inline-flex items-center gap-1 font-mono text-xs text-text-secondary">
       <span>{truncated}</span>
       <button
-        onClick={() => navigator.clipboard.writeText(address)}
-        className="text-text-muted hover:text-accent"
+        onClick={handleCopy}
+        className="text-text-muted hover:text-accent transition-colors"
         title="Copy"
       >
-        copy
+        {copied ? 'copied!' : 'copy'}
       </button>
       {explorerUrl && (
         <a


### PR DESCRIPTION
## Summary
- Feed: hide table headers on mobile, compact 2-row FeedLine layout
- TrustSnapshot: responsive grid (2→3→5 cols by breakpoint)
- AddressChip + ApiKeysPanel: "copied!" feedback on copy actions
- ClaimedAgentsList + AlertsPanel: animated skeleton loading states
- Page titles standardized to text-2xl across all pages
- FeedFilters: 300ms debounce on agent ID input
- StatusBar: real feed activity detection (idle after 90s no events)

## Test plan
- [ ] Mobile: Feed rows show compact 2-row layout, no broken grid
- [ ] Mobile: TrustSnapshot wraps to 2 columns
- [ ] Copy any address → button shows "copied!" for 1.5s
- [ ] Console: loading state shows skeleton cards
- [ ] Console + API Docs page titles match Feed/Discovery (text-2xl)
- [ ] StatusBar shows "Feed Idle" when no new events arrive
- [ ] `pnpm build` clean, `pnpm test` 153/153

Wolfcito 🐾 @akawolfcito