### PR TITLE
fix: Agent Dossier mobile layout + button consistency

### DIFF
--- a/src/app/agent/[chain]/[id]/page.tsx
+++ b/src/app/agent/[chain]/[id]/page.tsx
@@ -186,9 +186,9 @@ export default async function AgentPage({ params }: Props) {
     <div className="h-full overflow-y-auto">
       <div className="bg-grid mx-auto max-w-6xl px-6 py-10">
         {/* Header */}
-        <div className="flex items-start justify-between">
-          <div>
-            <div className="flex items-center gap-3 mb-2">
+        <div className="flex flex-col md:flex-row md:items-start md:justify-between gap-4">
+          <div className="min-w-0">
+            <div className="flex flex-wrap items-center gap-2 md:gap-3 mb-2">
               <h1 className="font-display text-2xl font-bold text-text-primary">
                 {metadata?.name ?? `Agent #${agentId}`}
               </h1>
@@ -203,7 +203,7 @@ export default async function AgentPage({ params }: Props) {
               </p>
             )}
 
-            <div className="flex items-center gap-6 text-xs font-mono text-text-muted">
+            <div className="flex flex-wrap items-center gap-3 md:gap-6 text-xs font-mono text-text-muted">
               <span>Agent #{agentId}</span>
               <span>Last seen: {formatRelativeTime(dossier.lastSeen)}</span>
               <span>{dossier.totalEvents} events</span>
@@ -211,38 +211,40 @@ export default async function AgentPage({ params }: Props) {
             </div>
           </div>
 
-          {/* Trust Score — right side */}
-          <div className="text-right shrink-0">
+          {/* Trust Score */}
+          <div className="text-left md:text-right shrink-0">
             {trustScore ? (
-              <div>
+              <div className="flex md:block items-center gap-3">
                 <span className={`font-display text-5xl font-bold ${scoreColor(trustScore.score)}`}>
                   {trustScore.score}
                 </span>
-                <span className="text-xs text-text-muted font-mono block mt-1">/ 100</span>
-                <span className={`status-pill ${confidencePill(trustScore.confidence)} text-[10px] mt-1`}>
-                  {trustScore.confidence.toUpperCase()}
-                </span>
+                <div className="md:mt-1">
+                  <span className="text-xs text-text-muted font-mono block">/ 100</span>
+                  <span className={`status-pill ${confidencePill(trustScore.confidence)} text-[10px] mt-1`}>
+                    {trustScore.confidence.toUpperCase()}
+                  </span>
+                </div>
               </div>
             ) : (
               <div className="text-xs text-text-muted font-mono">
-                Awaiting<br />first poll
+                Awaiting first poll
               </div>
             )}
           </div>
         </div>
 
         {/* Actions */}
-        <div className="mt-6 flex items-center gap-3">
+        <div className="mt-6 flex flex-wrap items-center gap-3">
           {/* Watch Agent — placeholder, disabled */}
           <button
             disabled
-            className="border border-border bg-surface px-4 py-1.5 text-xs font-mono text-text-muted cursor-not-allowed opacity-50"
+            className="border border-border bg-surface px-3 py-1.5 text-xs font-mono text-text-muted cursor-not-allowed opacity-50"
             title="Coming soon"
           >
             Watch Agent
           </button>
 
-          <span className="border-l border-border h-5 mx-1" />
+          <span className="hidden md:inline-block border-l border-border h-5 mx-1" />
 
           {/* Secondary CTAs */}
           <a
@@ -276,9 +278,9 @@ export default async function AgentPage({ params }: Props) {
         </div>
 
         {/* 12-column grid */}
-        <div className="grid grid-cols-12 gap-6 mt-8">
+        <div className="grid grid-cols-1 md:grid-cols-12 gap-6 mt-8">
           {/* Left column: Identity Card */}
-          <div className="col-span-4">
+          <div className="md:col-span-4">
             <div className="bg-surface border border-border p-6 space-y-5">
               {/* ERC-8004 label */}
               <div className="flex items-center justify-end">
@@ -348,7 +350,7 @@ export default async function AgentPage({ params }: Props) {
           </div>
 
           {/* Right column */}
-          <div className="col-span-8 space-y-6">
+          <div className="md:col-span-8 space-y-6">
             {/* What Changed */}
             <WhatChanged
               activity={{

--- a/src/components/auth/ClaimButton.tsx
+++ b/src/components/auth/ClaimButton.tsx
@@ -95,7 +95,7 @@ export function ClaimButton({ chainId, agentId, ownerAddress, onClaimed }: Claim
       <button
         onClick={handleClaim}
         disabled={state === 'signing' || state === 'verifying'}
-        className="border border-accent/30 bg-accent/5 px-4 py-1.5 text-xs font-mono text-accent hover:bg-accent/10 hover:border-accent/50 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+        className="border border-accent/30 bg-accent/5 px-3 py-1.5 text-xs font-mono text-accent hover:bg-accent/10 hover:border-accent/50 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
       >
         {state === 'signing' && 'Sign message...'}
         {state === 'verifying' && 'Verifying...'}

--- a/src/components/console/AlertsPanel.tsx
+++ b/src/components/console/AlertsPanel.tsx
@@ -180,14 +180,14 @@ export function AlertsPanel() {
           <button
             onClick={handleSaveWebhook}
             disabled={saving}
-            className="border border-accent/30 bg-accent/5 px-3 py-1 text-xs font-mono text-accent hover:bg-accent/10 transition-colors disabled:opacity-50"
+            className="border border-accent/30 bg-accent/5 px-3 py-1.5 text-xs font-mono text-accent hover:bg-accent/10 transition-colors disabled:opacity-50"
           >
             {saving ? 'Saving...' : 'Save'}
           </button>
           <button
             onClick={handleTestWebhook}
             disabled={testing || !webhookUrl}
-            className="border border-border bg-surface px-3 py-1 text-xs font-mono text-text-secondary hover:border-border-bright transition-colors disabled:opacity-50"
+            className="border border-border bg-surface px-3 py-1.5 text-xs font-mono text-text-secondary hover:bg-surface-hover hover:text-text-primary hover:border-border-bright transition-colors disabled:opacity-50"
           >
             {testing ? 'Sending...' : 'Test'}
           </button>

--- a/src/components/console/ApiKeysPanel.tsx
+++ b/src/components/console/ApiKeysPanel.tsx
@@ -76,7 +76,7 @@ export function ApiKeysPanel() {
         <button
           onClick={handleCreate}
           disabled={creating || keys.length >= 5}
-          className="bg-accent text-background px-4 py-1.5 text-xs font-mono font-bold hover:opacity-90 disabled:opacity-50"
+          className="bg-accent text-bg px-4 py-1.5 text-xs font-mono font-bold hover:bg-accent/90 transition-colors disabled:opacity-50"
         >
           {creating ? 'Creating...' : 'Generate Key'}
         </button>

--- a/src/components/console/RegisterAgentPanel.tsx
+++ b/src/components/console/RegisterAgentPanel.tsx
@@ -314,7 +314,7 @@ export function RegisterAgentPanel() {
             <button
               onClick={handleRegister}
               disabled={isWorking || !name.trim() || !description.trim()}
-              className="bg-accent text-background px-4 py-1.5 text-xs font-mono font-bold hover:opacity-90 disabled:opacity-50"
+              className="bg-accent text-bg px-4 py-1.5 text-xs font-mono font-bold hover:bg-accent/90 transition-colors disabled:opacity-50"
             >
               {status === 'uploading'
                 ? 'Uploading to IPFS...'


### PR DESCRIPTION
## Summary
- Agent Dossier page: responsive layout that stacks on mobile (header, trust score, actions, 12-col grid)
- Buttons: standardized padding and hover states across Console panels (AlertsPanel, ApiKeysPanel, RegisterAgentPanel, ClaimButton)

## Test plan
- [ ] Mobile: Dossier page header stacks (title above, trust score below)
- [ ] Mobile: Actions row wraps naturally
- [ ] Mobile: Identity card + right column stack vertically
- [ ] Desktop: unchanged 2-column layout
- [ ] Console buttons: consistent padding (px-3/px-4) and hover feedback
- [ ] `pnpm build` clean, `pnpm test` 153/153

Wolfcito 🐾 @akawolfcito