### PR TITLE
fix: use wallet chainId for chain switch during registration

### DIFF
--- a/src/components/console/RegisterAgentPanel.tsx
+++ b/src/components/console/RegisterAgentPanel.tsx
@@ -3,7 +3,6 @@
 import { useState, useRef, useCallback } from 'react'
 import {
   useAccount,
-  useChainId,
   useSwitchChain,
   useWriteContract,
   useWaitForTransactionReceipt,
@@ -17,8 +16,7 @@ import { uploadAgentMetadata } from '@/lib/ipfs/upload'
 type Status = 'idle' | 'uploading' | 'signing' | 'confirming' | 'success' | 'error'
 
 export function RegisterAgentPanel() {
-  const { address } = useAccount()
-  const currentChainId = useChainId()
+  const { address, chainId: walletChainId } = useAccount()
   const { switchChainAsync } = useSwitchChain()
   const { writeContractAsync } = useWriteContract()
   const [txHash, setTxHash] = useState<`0x${string}` | undefined>()
@@ -118,8 +116,8 @@ export function RegisterAgentPanel() {
         chainId: selectedChainId,
       })
 
-      // Switch chain if needed
-      if (currentChainId !== selectedChainId) {
+      // Switch wallet to target chain if needed
+      if (walletChainId !== selectedChainId) {
         await switchChainAsync({ chainId: selectedChainId })
       }
 


### PR DESCRIPTION
## Summary
- `useChainId()` returns wagmi's app-side chain, not the wallet's actual chain
- When wallet is on Base (8453) but user selects Celo (42220) in the dropdown, `useChainId()` already reports 42220 → skips `switchChainAsync` → `writeContract` fails with `ChainMismatchError`
- Fix: use `useAccount().chainId` which reflects the wallet's real connected chain

## Test plan
- [ ] Connect wallet on Base → select Celo Sepolia → Register → wallet prompts chain switch → tx succeeds
- [ ] Connect wallet already on Celo → Register → no switch prompt → tx succeeds
- [ ] `pnpm build` clean, `pnpm test` 153/153

Wolfcito 🐾 @akawolfcito