### PR TITLE
fix(console): prevent infinite re-render after registration

### DIFF
--- a/src/components/console/RegisterAgentPanel.tsx
+++ b/src/components/console/RegisterAgentPanel.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useRef, useCallback } from 'react'
+import { useState, useRef, useCallback, useEffect } from 'react'
 import {
   useAccount,
   useSwitchChain,
@@ -70,33 +70,32 @@ export function RegisterAgentPanel() {
     }
   }, [])
 
-  const { isLoading: isConfirming } = useWaitForTransactionReceipt({
+  const { data: receipt, isLoading: isConfirming } = useWaitForTransactionReceipt({
     hash: txHash,
-    query: {
-      enabled: !!txHash,
-      select(receipt) {
-        for (const log of receipt.logs) {
-          try {
-            const decoded = decodeEventLog({
-              abi: identityRegistryAbi,
-              data: log.data,
-              topics: log.topics,
-            })
-            if (decoded.eventName === 'Registered') {
-              const id = (decoded.args as { agentId: bigint }).agentId.toString()
-              setAgentId(id)
-              setStatus('success')
-              return receipt
-            }
-          } catch {
-            // not our event, skip
-          }
-        }
-        setStatus('success')
-        return receipt
-      },
-    },
+    query: { enabled: !!txHash },
   })
+
+  useEffect(() => {
+    if (!receipt) return
+    for (const log of receipt.logs) {
+      try {
+        const decoded = decodeEventLog({
+          abi: identityRegistryAbi,
+          data: log.data,
+          topics: log.topics,
+        })
+        if (decoded.eventName === 'Registered') {
+          const id = (decoded.args as { agentId: bigint }).agentId.toString()
+          setAgentId(id)
+          setStatus('success')
+          return
+        }
+      } catch {
+        // not our event, skip
+      }
+    }
+    setStatus('success')
+  }, [receipt])
 
   const selectedChain = chains.find((c) => c.id === selectedChainId)!
 


### PR DESCRIPTION
## Summary
- Move event decoding + state updates from `useWaitForTransactionReceipt`'s `select()` callback into a `useEffect`
- `select()` runs during render — calling `setState` inside it caused an infinite loop (React error #301) when the tx receipt arrived after registering on Celo Sepolia
- Build passes, 153/153 tests pass

## Test plan
- [ ] Deploy to Vercel preview
- [ ] Connect wallet, register agent on Celo Sepolia
- [ ] Verify success state renders without crash after tx confirms
- [ ] Verify agent ID link works

Wolfcito 🐾 @akawolfcito