### PR TITLE
test: add Playwright E2E for public UI flows (18 tests)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@
 
 # testing
 /coverage
+/playwright-report/
+/test-results/
 
 # next.js
 /.next/

--- a/e2e/agent-detail.spec.ts
+++ b/e2e/agent-detail.spec.ts
@@ -1,0 +1,56 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Agent Detail Page', () => {
+  test('agent detail page loads for /agent/42220/1', async ({ page }) => {
+    const response = await page.goto('/agent/42220/1');
+    // SSR page should return 200 even if agent data is minimal
+    expect(response?.status()).toBeLessThan(500);
+    await expect(page.locator('body')).toBeVisible();
+  });
+
+  test('shows agent ID in the page content', async ({ page }) => {
+    await page.goto('/agent/42220/1');
+    // The page should reference the agent ID somewhere in the content
+    const body = await page.locator('body').textContent();
+    expect(body).toBeTruthy();
+    // Agent ID 1 or chain 42220 should appear in the rendered content
+    const hasAgentRef =
+      body?.includes('1') || body?.includes('42220') || body?.includes('Celo');
+    expect(hasAgentRef).toBe(true);
+  });
+
+  test('shows chain information (Celo)', async ({ page }) => {
+    await page.goto('/agent/42220/1');
+    const body = await page.locator('body').textContent();
+    // Chain 42220 is Celo — expect some reference to Celo or the chain
+    const hasCeloRef =
+      body?.includes('Celo') ||
+      body?.includes('42220') ||
+      body?.includes('celo');
+    expect(hasCeloRef).toBe(true);
+  });
+
+  test('has share or certificate actions visible', async ({ page }) => {
+    await page.goto('/agent/42220/1');
+    // Look for share/certificate buttons or links in the page
+    const shareButton = page.getByRole('button', { name: /share/i });
+    const certButton = page.getByRole('button', { name: /certificate/i });
+    const shareLink = page.getByRole('link', { name: /share/i });
+    const certLink = page.getByRole('link', { name: /certificate/i });
+
+    const hasShareAction =
+      (await shareButton.count()) > 0 || (await shareLink.count()) > 0;
+    const hasCertAction =
+      (await certButton.count()) > 0 || (await certLink.count()) > 0;
+
+    // At least one action should be present
+    expect(hasShareAction || hasCertAction).toBe(true);
+  });
+
+  test('unknown agent shows graceful empty state', async ({ page }) => {
+    const response = await page.goto('/agent/42220/999999');
+    // Should not crash — either 200 with empty state or 404
+    expect(response?.status()).toBeLessThan(500);
+    await expect(page.locator('body')).toBeVisible();
+  });
+});

--- a/e2e/api-routes.spec.ts
+++ b/e2e/api-routes.spec.ts
@@ -1,0 +1,64 @@
+import { test, expect } from '@playwright/test';
+
+// Some API routes require Supabase env vars to be configured.
+// If they are not set, routes may return 500. We handle this gracefully.
+const SUPABASE_CONFIGURED = !!process.env.NEXT_PUBLIC_SUPABASE_URL;
+
+test.describe('API Routes', () => {
+  test('GET /api/v1/agent/42220/1 returns JSON', async ({ request }) => {
+    const response = await request.get('/api/v1/agent/42220/1');
+    // Without auth: expect 401, 402, or 200 if public
+    // With missing Supabase: may get 500
+    const status = response.status();
+    expect([200, 401, 402, 500]).toContain(status);
+
+    if (status !== 500) {
+      const contentType = response.headers()['content-type'] ?? '';
+      expect(contentType).toContain('application/json');
+    }
+  });
+
+  test('GET /api/v1/agent/42220/1/score without auth returns 401 or 402', async ({
+    request,
+  }) => {
+    const response = await request.get('/api/v1/agent/42220/1/score');
+    const status = response.status();
+    // Without auth header: should be 401 (no key) or 402 (payment required) or 500 (no Supabase)
+    expect([401, 402, 500]).toContain(status);
+  });
+
+  test('GET /api/v1/search without auth returns 401', async ({ request }) => {
+    const response = await request.get('/api/v1/search');
+    const status = response.status();
+    expect([401, 402, 500]).toContain(status);
+  });
+
+  test.skip(
+    !SUPABASE_CONFIGURED,
+    'GET /api/v1/search response format check (requires Supabase)'
+  );
+  test('GET /api/v1/search response format check', async ({ request }) => {
+    // This test only runs when Supabase is configured
+    const response = await request.get('/api/v1/search?q=test', {
+      headers: { 'X-API-Key': 'ds_test_placeholder' },
+    });
+    const status = response.status();
+    // With an invalid key we expect 401; with valid key we'd get JSON array
+    expect([200, 401, 402]).toContain(status);
+  });
+
+  test('GET /api/auth/nonce returns a nonce', async ({ request }) => {
+    const response = await request.get('/api/auth/nonce');
+    const status = response.status();
+
+    if (status === 200) {
+      const body = await response.json();
+      // Nonce should be a non-empty string
+      expect(body.nonce).toBeTruthy();
+      expect(typeof body.nonce).toBe('string');
+    } else {
+      // If Supabase is not configured, nonce generation may fail
+      expect([200, 500]).toContain(status);
+    }
+  });
+});

--- a/e2e/docs.spec.ts
+++ b/e2e/docs.spec.ts
@@ -1,0 +1,29 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('API Documentation Page', () => {
+  test('/docs/api page loads', async ({ page }) => {
+    const response = await page.goto('/docs/api');
+    expect(response?.status()).toBe(200);
+    await expect(page).toHaveTitle(/DenScope/i);
+  });
+
+  test('contains API documentation content', async ({ page }) => {
+    await page.goto('/docs/api');
+    const body = await page.locator('body').textContent();
+    // The docs page should mention API-related terms
+    const hasApiContent =
+      body?.includes('API') ||
+      body?.includes('endpoint') ||
+      body?.includes('Endpoint') ||
+      body?.includes('/api/');
+    expect(hasApiContent).toBe(true);
+  });
+
+  test('has code examples visible', async ({ page }) => {
+    await page.goto('/docs/api');
+    // Look for code blocks (pre or code elements) on the docs page
+    const codeBlocks = page.locator('pre, code');
+    const count = await codeBlocks.count();
+    expect(count).toBeGreaterThan(0);
+  });
+});

--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -1,0 +1,40 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Navigation', () => {
+  test('home page loads and shows feed content or empty state', async ({
+    page,
+  }) => {
+    await page.goto('/');
+    await expect(page).toHaveTitle(/DenScope/i);
+    // The page should render without errors — look for the main layout
+    await expect(page.locator('body')).toBeVisible();
+  });
+
+  test('navigation to /graph shows the trust graph page', async ({ page }) => {
+    await page.goto('/graph');
+    await expect(page).toHaveTitle(/DenScope/i);
+    await expect(page.locator('body')).toBeVisible();
+  });
+
+  test('navigation to /discovery shows the discovery page', async ({
+    page,
+  }) => {
+    await page.goto('/discovery');
+    await expect(page).toHaveTitle(/DenScope/i);
+    await expect(page.locator('body')).toBeVisible();
+  });
+
+  test('navigation to /docs/api shows API documentation', async ({ page }) => {
+    await page.goto('/docs/api');
+    await expect(page).toHaveTitle(/DenScope/i);
+    await expect(page.locator('body')).toBeVisible();
+  });
+
+  test('page titles contain DenScope', async ({ page }) => {
+    const routes = ['/', '/graph', '/discovery', '/docs/api'];
+    for (const route of routes) {
+      await page.goto(route);
+      await expect(page).toHaveTitle(/DenScope/i);
+    }
+  });
+});

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
     "indexer:backfill": "tsx scripts/indexer.ts --backfill-only",
     "og:candidates": "tsx scripts/og-review-candidates.ts",
     "og:fetch": "tsx scripts/fetch-og-cards.ts",
-    "perf:review": "tsx scripts/perf-review-template.ts"
+    "perf:review": "tsx scripts/perf-review-template.ts",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.95.3",
@@ -40,6 +42,7 @@
     ]
   },
   "devDependencies": {
+    "@playwright/test": "^1.58.2",
     "@tailwindcss/postcss": "^4",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,33 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: 'e2e',
+  timeout: 30_000,
+  expect: {
+    timeout: 10_000,
+  },
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: 'html',
+
+  use: {
+    baseURL: 'http://localhost:3000',
+    trace: 'on-first-retry',
+  },
+
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+
+  webServer: {
+    command: 'pnpm dev',
+    url: 'http://localhost:3000',
+    reuseExistingServer: true,
+    timeout: 60_000,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,7 +37,7 @@ importers:
         version: 8.0.3
       next:
         specifier: 16.1.6
-        version: 16.1.6(@babel/core@7.29.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 16.1.6(@babel/core@7.29.0)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react:
         specifier: 19.2.3
         version: 19.2.3
@@ -57,6 +57,9 @@ importers:
         specifier: ^5.0.11
         version: 5.0.11(@types/react@19.2.14)(react@19.2.3)(use-sync-external-store@1.4.0(react@19.2.3))
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.58.2
+        version: 1.58.2
       '@tailwindcss/postcss':
         specifier: ^4
         version: 4.1.18
@@ -736,6 +739,11 @@ packages:
   '@nolyfill/is-core-module@1.0.39':
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
+
+  '@playwright/test@1.58.2':
+    resolution: {integrity: sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@rolldown/pluginutils@1.0.0-rc.3':
     resolution: {integrity: sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==}
@@ -1932,6 +1940,11 @@ packages:
       react-dom:
         optional: true
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -2548,6 +2561,16 @@ packages:
   picomatch@4.0.3:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
+
+  playwright-core@1.58.2:
+    resolution: {integrity: sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.58.2:
+    resolution: {integrity: sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -3643,6 +3666,10 @@ snapshots:
       fastq: 1.20.1
 
   '@nolyfill/is-core-module@1.0.39': {}
+
+  '@playwright/test@1.58.2':
+    dependencies:
+      playwright: 1.58.2
 
   '@rolldown/pluginutils@1.0.0-rc.3': {}
 
@@ -4979,6 +5006,9 @@ snapshots:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -5459,7 +5489,7 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  next@16.1.6(@babel/core@7.29.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  next@16.1.6(@babel/core@7.29.0)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       '@next/env': 16.1.6
       '@swc/helpers': 0.5.15
@@ -5478,6 +5508,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 16.1.6
       '@next/swc-win32-arm64-msvc': 16.1.6
       '@next/swc-win32-x64-msvc': 16.1.6
+      '@playwright/test': 1.58.2
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -5588,6 +5619,14 @@ snapshots:
   picomatch@2.3.1: {}
 
   picomatch@4.0.3: {}
+
+  playwright-core@1.58.2: {}
+
+  playwright@1.58.2:
+    dependencies:
+      playwright-core: 1.58.2
+    optionalDependencies:
+      fsevents: 2.3.2
 
   possible-typed-array-names@1.1.0: {}
 


### PR DESCRIPTION
## Summary
- Set up Playwright with chromium + webServer auto-start
- 18 E2E tests across 4 suites: navigation, agent-detail, api-routes, docs
- 13 passing, 5 skipped (Supabase-dependent, graceful skip)
- Add test:e2e and test:e2e:ui scripts
- Add playwright-report/ and test-results/ to .gitignore

## Test plan
- [x] `pnpm test:e2e` — 13 passed, 5 skipped
- [x] No wallet/SIWE flows (only public UI + API)
- [x] No secrets in test files

Wolfcito 🐾 @akawolfcito