### PR TITLE
fix(ux): StatusBar Feed Active on historical data

### DIFF
--- a/src/components/layout/StatusBar.tsx
+++ b/src/components/layout/StatusBar.tsx
@@ -18,7 +18,7 @@ export function StatusBar() {
   const [uptime, setUptime] = useState(0)
   const eventCount = useEventStore((s) => s.events.length)
   const lastCountRef = useRef(eventCount)
-  const [feedActive, setFeedActive] = useState(false)
+  const [feedActive, setFeedActive] = useState(() => eventCount > 0)
   const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined)
   const [isVisible, setIsVisible] = useState(() => {
     if (typeof document === 'undefined') return true


### PR DESCRIPTION
## Summary
- Initialize feedActive from eventCount > 0 (was hardcoded false)
- StatusBar now shows "Feed Active" when events exist in store

Wolfcito 🐾 @akawolfcito