### PR TITLE
fix(security): SIWE domain binding — prevent cross-app replay

### DIFF
--- a/src/lib/auth/__tests__/verify.test.ts
+++ b/src/lib/auth/__tests__/verify.test.ts
@@ -6,6 +6,7 @@ vi.mock('siwe', () => {
   return {
     SiweMessage: class {
       address = '0xTestAddress'
+      domain = 'denscope.vercel.app'
       verify = mockVerify
     },
   }

--- a/src/lib/auth/verify.ts
+++ b/src/lib/auth/verify.ts
@@ -1,5 +1,7 @@
 import { SiweMessage } from 'siwe'
 
+const DOMAIN = process.env.NEXT_PUBLIC_APP_DOMAIN ?? 'denscope.vercel.app'
+
 type VerifyResult =
   | { valid: true; address: string }
   | { valid: false; error: string }
@@ -10,7 +12,12 @@ export async function verifySiweMessage(
 ): Promise<VerifyResult> {
   try {
     const siweMessage = new SiweMessage(message)
-    const result = await siweMessage.verify({ signature })
+
+    if (siweMessage.domain !== DOMAIN) {
+      return { valid: false, error: 'Domain mismatch' }
+    }
+
+    const result = await siweMessage.verify({ signature, domain: DOMAIN })
     if (!result.success) {
       return { valid: false, error: 'Signature verification failed' }
     }


### PR DESCRIPTION
## Summary
- Add domain validation to verifySiweMessage (checks against NEXT_PUBLIC_APP_DOMAIN)
- Prevents cross-app SIWE signature replay attacks
- Update verify tests with domain property in mock

## Test plan
- [x] 214/214 tests passing

Wolfcito 🐾 @akawolfcito