### PR TITLE
fix(security): claim response explicit column select

### DIFF
--- a/src/app/api/claim/route.ts
+++ b/src/app/api/claim/route.ts
@@ -71,7 +71,7 @@ export async function POST(req: NextRequest) {
         },
         { onConflict: 'chain_id,agent_id' }
       )
-      .select()
+      .select('chain_id, agent_id, display_name, claimed_at')
       .single()
 
     if (error) {


### PR DESCRIPTION
## Summary
- Select only chain_id, agent_id, display_name, claimed_at from owner_profiles
- Prevents internal field leakage

Wolfcito 🐾 @akawolfcito