### PR TITLE
fix(security): session auth + SSRF protection — resolve 4 CRITICALs

### DIFF
--- a/src/app/api/alerts/rules/route.ts
+++ b/src/app/api/alerts/rules/route.ts
@@ -1,18 +1,32 @@
-// src/app/api/alerts/rules/route.ts
 import { NextRequest, NextResponse } from 'next/server'
 import { supabaseAdmin } from '@/lib/supabase/admin'
+import { requireSession } from '@/lib/auth/session'
 import { buildDefaultRules } from '@/lib/supabase/alerts'
 
-// GET: fetch alert rules for an agent
 export async function GET(req: NextRequest) {
+  const session = await requireSession()
+  if (!session.ok) {
+    return NextResponse.json({ error: 'Authentication required' }, { status: 401 })
+  }
+
   const chainId = req.nextUrl.searchParams.get('chainId')
   const agentId = req.nextUrl.searchParams.get('agentId')
 
   if (!chainId || !agentId) {
-    return NextResponse.json(
-      { error: 'Missing chainId or agentId' },
-      { status: 400 }
-    )
+    return NextResponse.json({ error: 'Missing chainId or agentId' }, { status: 400 })
+  }
+
+  // Verify caller owns this agent
+  const { data: profile } = await supabaseAdmin
+    .from('owner_profiles')
+    .select('wallet_address')
+    .eq('chain_id', Number(chainId))
+    .eq('agent_id', Number(agentId))
+    .eq('wallet_address', session.address)
+    .maybeSingle()
+
+  if (!profile) {
+    return NextResponse.json({ error: 'Not the owner of this agent' }, { status: 403 })
   }
 
   const { data } = await supabaseAdmin
@@ -25,20 +39,21 @@ export async function GET(req: NextRequest) {
   return NextResponse.json({ rules: data ?? [] })
 }
 
-// POST: initialize default rules for an agent (called after claim)
 export async function POST(req: NextRequest) {
-  try {
-    const { ownerAddress, chainId, agentId } = await req.json()
+  const session = await requireSession()
+  if (!session.ok) {
+    return NextResponse.json({ error: 'Authentication required' }, { status: 401 })
+  }
 
-    if (!ownerAddress || !chainId || !agentId) {
-      return NextResponse.json(
-        { error: 'Missing required fields' },
-        { status: 400 }
-      )
+  try {
+    const { chainId, agentId } = await req.json()
+
+    if (!chainId || !agentId) {
+      return NextResponse.json({ error: 'Missing required fields' }, { status: 400 })
     }
 
     const rows = buildDefaultRules({
-      ownerAddress: ownerAddress.toLowerCase(),
+      ownerAddress: session.address,
       chainId,
       agentId,
     })
@@ -50,32 +65,38 @@ export async function POST(req: NextRequest) {
 
     if (error) {
       console.error('Alert rules init error:', error)
-      return NextResponse.json(
-        { error: 'Failed to create alert rules' },
-        { status: 500 }
-      )
+      return NextResponse.json({ error: 'Failed to create alert rules' }, { status: 500 })
     }
 
     return NextResponse.json({ rules: data })
   } catch (err) {
     console.error('Alert rules error:', err)
-    return NextResponse.json(
-      { error: 'Internal server error' },
-      { status: 500 }
-    )
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
   }
 }
 
-// PATCH: toggle rule enabled/disabled or set webhook URL
 export async function PATCH(req: NextRequest) {
+  const session = await requireSession()
+  if (!session.ok) {
+    return NextResponse.json({ error: 'Authentication required' }, { status: 401 })
+  }
+
   try {
     const { ruleId, enabled, webhookUrl } = await req.json()
 
     if (!ruleId) {
-      return NextResponse.json(
-        { error: 'Missing ruleId' },
-        { status: 400 }
-      )
+      return NextResponse.json({ error: 'Missing ruleId' }, { status: 400 })
+    }
+
+    // Verify caller owns the rule
+    const { data: rule } = await supabaseAdmin
+      .from('alert_rules')
+      .select('owner_address')
+      .eq('id', ruleId)
+      .maybeSingle()
+
+    if (!rule || rule.owner_address !== session.address) {
+      return NextResponse.json({ error: 'Rule not found' }, { status: 404 })
     }
 
     const updates: Record<string, unknown> = {
@@ -92,18 +113,12 @@ export async function PATCH(req: NextRequest) {
       .single()
 
     if (error) {
-      return NextResponse.json(
-        { error: 'Rule not found' },
-        { status: 404 }
-      )
+      return NextResponse.json({ error: 'Update failed' }, { status: 500 })
     }
 
     return NextResponse.json({ rule: data })
   } catch (err) {
     console.error('Alert rules patch error:', err)
-    return NextResponse.json(
-      { error: 'Internal server error' },
-      { status: 500 }
-    )
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
   }
 }

--- a/src/app/api/alerts/webhook-test/route.ts
+++ b/src/app/api/alerts/webhook-test/route.ts
@@ -1,15 +1,23 @@
-// src/app/api/alerts/webhook-test/route.ts
 import { NextRequest, NextResponse } from 'next/server'
+import { requireSession } from '@/lib/auth/session'
+import { validateWebhookUrl } from '@/lib/security/url-validator'
 
 export async function POST(req: NextRequest) {
+  const session = await requireSession()
+  if (!session.ok) {
+    return NextResponse.json({ error: 'Authentication required' }, { status: 401 })
+  }
+
   try {
     const { webhookUrl } = await req.json()
 
     if (!webhookUrl) {
-      return NextResponse.json(
-        { error: 'Missing webhookUrl' },
-        { status: 400 }
-      )
+      return NextResponse.json({ error: 'Missing webhookUrl' }, { status: 400 })
+    }
+
+    const urlCheck = validateWebhookUrl(webhookUrl)
+    if (!urlCheck.safe) {
+      return NextResponse.json({ error: urlCheck.reason }, { status: 400 })
     }
 
     const testPayload = {
@@ -26,7 +34,7 @@ export async function POST(req: NextRequest) {
       consoleUrl: 'https://denscope.vercel.app/console',
     }
 
-    const res = await fetch(webhookUrl, {
+    const res = await fetch(urlCheck.url, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(testPayload),

--- a/src/app/api/claim/route.ts
+++ b/src/app/api/claim/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { verifySiweMessage } from '@/lib/auth/verify'
+import { createSession } from '@/lib/auth/session'
 import { readAgentOwner } from '@/lib/agent/read'
 import { getChain } from '@/config/chains'
 import { supabaseAdmin } from '@/lib/supabase/admin'
@@ -81,6 +82,9 @@ export async function POST(req: NextRequest) {
         { status: 500 }
       )
     }
+
+    // Set session cookie
+    await createSession(result.address)
 
     return NextResponse.json({ claimed: true, profile: data })
   } catch (err) {

--- a/src/app/api/incidents/resolve/route.ts
+++ b/src/app/api/incidents/resolve/route.ts
@@ -1,7 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { supabaseAdmin } from '@/lib/supabase/admin'
+import { requireSession } from '@/lib/auth/session'
 
 export async function POST(req: NextRequest) {
+  const session = await requireSession()
+  if (!session.ok) {
+    return NextResponse.json({ error: 'Authentication required' }, { status: 401 })
+  }
+
   try {
     const { incidentId } = await req.json()
 
@@ -12,18 +18,41 @@ export async function POST(req: NextRequest) {
       )
     }
 
+    // Verify caller owns the agent this incident belongs to
+    const { data: incident } = await supabaseAdmin
+      .from('incidents')
+      .select('chain_id, agent_id')
+      .eq('id', incidentId)
+      .maybeSingle()
+
+    if (!incident) {
+      return NextResponse.json({ error: 'Incident not found' }, { status: 404 })
+    }
+
+    const { data: profile } = await supabaseAdmin
+      .from('owner_profiles')
+      .select('wallet_address')
+      .eq('chain_id', incident.chain_id)
+      .eq('agent_id', incident.agent_id)
+      .eq('wallet_address', session.address)
+      .maybeSingle()
+
+    if (!profile) {
+      return NextResponse.json({ error: 'Not the owner of this agent' }, { status: 403 })
+    }
+
     const { data, error } = await supabaseAdmin
       .from('incidents')
       .update({ resolved_at: new Date().toISOString() })
       .eq('id', incidentId)
       .is('resolved_at', null)
-      .select()
+      .select('id, chain_id, agent_id, signal_kind, resolved_at')
       .single()
 
     if (error) {
       return NextResponse.json(
-        { error: 'Incident not found or already resolved' },
-        { status: 404 }
+        { error: 'Incident already resolved' },
+        { status: 409 }
       )
     }
 

--- a/src/app/api/ipfs/upload-file/route.ts
+++ b/src/app/api/ipfs/upload-file/route.ts
@@ -1,9 +1,15 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { requireSession } from '@/lib/auth/session'
 
 const MAX_SIZE = 5 * 1024 * 1024 // 5 MB
-const ALLOWED_TYPES = ['image/png', 'image/jpeg', 'image/webp', 'image/gif', 'image/svg+xml']
+const ALLOWED_TYPES = ['image/png', 'image/jpeg', 'image/webp', 'image/gif']
 
 export async function POST(req: NextRequest) {
+  const session = await requireSession()
+  if (!session.ok) {
+    return NextResponse.json({ error: 'Authentication required' }, { status: 401 })
+  }
+
   try {
     const jwt = process.env.PINATA_JWT
     if (!jwt) {

--- a/src/app/api/ipfs/upload/route.ts
+++ b/src/app/api/ipfs/upload/route.ts
@@ -1,7 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getChain } from '@/config/chains'
+import { requireSession } from '@/lib/auth/session'
 
 export async function POST(req: NextRequest) {
+  const session = await requireSession()
+  if (!session.ok) {
+    return NextResponse.json({ error: 'Authentication required' }, { status: 401 })
+  }
+
   try {
     const jwt = process.env.PINATA_JWT
     if (!jwt) {

--- a/src/app/api/v1/keys/route.ts
+++ b/src/app/api/v1/keys/route.ts
@@ -1,33 +1,36 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { supabaseAdmin } from '@/lib/supabase/admin'
+import { requireSession } from '@/lib/auth/session'
 import { generateApiKey, hashApiKey, getKeyPrefix } from '@/lib/api-keys/generate'
 
-export async function GET(req: NextRequest) {
-  const ownerAddress = req.nextUrl.searchParams.get('ownerAddress')
-  if (!ownerAddress) {
-    return NextResponse.json({ error: 'Missing ownerAddress' }, { status: 400 })
+export async function GET() {
+  const session = await requireSession()
+  if (!session.ok) {
+    return NextResponse.json({ error: 'Authentication required' }, { status: 401 })
   }
 
   const { data } = await supabaseAdmin
     .from('api_keys')
     .select('id, key_prefix, label, tier, daily_limit, enabled, last_used_at, created_at')
-    .eq('owner_address', ownerAddress.toLowerCase())
+    .eq('owner_address', session.address)
     .order('created_at', { ascending: false })
 
   return NextResponse.json({ keys: data ?? [] })
 }
 
 export async function POST(req: NextRequest) {
+  const session = await requireSession()
+  if (!session.ok) {
+    return NextResponse.json({ error: 'Authentication required' }, { status: 401 })
+  }
+
   try {
-    const { ownerAddress, label } = await req.json()
-    if (!ownerAddress) {
-      return NextResponse.json({ error: 'Missing ownerAddress' }, { status: 400 })
-    }
+    const { label } = await req.json()
 
     const { count } = await supabaseAdmin
       .from('api_keys')
       .select('id', { count: 'exact', head: true })
-      .eq('owner_address', ownerAddress.toLowerCase())
+      .eq('owner_address', session.address)
 
     if (count && count >= 5) {
       return NextResponse.json(
@@ -43,7 +46,7 @@ export async function POST(req: NextRequest) {
     const { data, error } = await supabaseAdmin
       .from('api_keys')
       .insert({
-        owner_address: ownerAddress.toLowerCase(),
+        owner_address: session.address,
         key_prefix: keyPrefix,
         key_hash: keyHash,
         label: label || 'default',
@@ -66,17 +69,22 @@ export async function POST(req: NextRequest) {
 }
 
 export async function DELETE(req: NextRequest) {
+  const session = await requireSession()
+  if (!session.ok) {
+    return NextResponse.json({ error: 'Authentication required' }, { status: 401 })
+  }
+
   try {
-    const { keyId, ownerAddress } = await req.json()
-    if (!keyId || !ownerAddress) {
-      return NextResponse.json({ error: 'Missing keyId or ownerAddress' }, { status: 400 })
+    const { keyId } = await req.json()
+    if (!keyId) {
+      return NextResponse.json({ error: 'Missing keyId' }, { status: 400 })
     }
 
     const { error } = await supabaseAdmin
       .from('api_keys')
       .delete()
       .eq('id', keyId)
-      .eq('owner_address', ownerAddress.toLowerCase())
+      .eq('owner_address', session.address)
 
     if (error) {
       return NextResponse.json({ error: 'Key not found' }, { status: 404 })

--- a/src/lib/auth/session.ts
+++ b/src/lib/auth/session.ts
@@ -1,0 +1,77 @@
+import { cookies } from 'next/headers'
+import { createHmac, timingSafeEqual } from 'crypto'
+
+const SESSION_COOKIE = 'denscope_session'
+const SESSION_MAX_AGE = 60 * 60 * 24 * 7 // 7 days
+
+function getSecret(): string {
+  const key = process.env.SESSION_SECRET ?? process.env.SUPABASE_SERVICE_ROLE_KEY
+  if (!key) throw new Error('Missing SESSION_SECRET (or SUPABASE_SERVICE_ROLE_KEY fallback) for session signing')
+  return key
+}
+
+function sign(payload: string): string {
+  return createHmac('sha256', getSecret()).update(payload).digest('hex')
+}
+
+function verify(payload: string, signature: string): boolean {
+  const expected = sign(payload)
+  try {
+    return timingSafeEqual(Buffer.from(expected), Buffer.from(signature))
+  } catch {
+    return false
+  }
+}
+
+type SessionPayload = {
+  address: string
+  iat: number
+}
+
+export async function createSession(address: string): Promise<void> {
+  const payload: SessionPayload = { address: address.toLowerCase(), iat: Date.now() }
+  const encoded = Buffer.from(JSON.stringify(payload)).toString('base64url')
+  const sig = sign(encoded)
+  const token = `${encoded}.${sig}`
+
+  const jar = await cookies()
+  jar.set(SESSION_COOKIE, token, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax',
+    maxAge: SESSION_MAX_AGE,
+    path: '/',
+  })
+}
+
+export async function getSession(): Promise<{ address: string } | null> {
+  const jar = await cookies()
+  const token = jar.get(SESSION_COOKIE)?.value
+  if (!token) return null
+
+  const dotIndex = token.indexOf('.')
+  if (dotIndex === -1) return null
+
+  const encoded = token.slice(0, dotIndex)
+  const sig = token.slice(dotIndex + 1)
+
+  if (!verify(encoded, sig)) return null
+
+  try {
+    const payload: SessionPayload = JSON.parse(
+      Buffer.from(encoded, 'base64url').toString()
+    )
+    if (Date.now() - payload.iat > SESSION_MAX_AGE * 1000) return null
+    return { address: payload.address }
+  } catch {
+    return null
+  }
+}
+
+export async function requireSession(): Promise<
+  { ok: true; address: string } | { ok: false; status: 401 }
+> {
+  const session = await getSession()
+  if (!session) return { ok: false, status: 401 }
+  return { ok: true, address: session.address }
+}

--- a/src/lib/security/url-validator.ts
+++ b/src/lib/security/url-validator.ts
@@ -1,0 +1,44 @@
+const PRIVATE_IP_PATTERNS = [
+  /^127\./,
+  /^10\./,
+  /^172\.(1[6-9]|2\d|3[01])\./,
+  /^192\.168\./,
+  /^169\.254\./,
+  /^0\./,
+  /^::1$/,
+  /^::ffff:127\./i,
+  /^fd/i,
+  /^fe80/i,
+  /^fc/i,
+  /^localhost$/i,
+]
+
+type ValidateResult =
+  | { safe: true; url: string }
+  | { safe: false; reason: string }
+
+export function validateWebhookUrl(url: string): ValidateResult {
+  try {
+    const parsed = new URL(url)
+
+    const isProduction = process.env.NODE_ENV === 'production'
+    if (isProduction && parsed.protocol !== 'https:') {
+      return { safe: false, reason: 'Only HTTPS URLs allowed in production' }
+    }
+
+    if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
+      return { safe: false, reason: 'Only HTTP(S) URLs allowed' }
+    }
+
+    const hostname = parsed.hostname
+    for (const pattern of PRIVATE_IP_PATTERNS) {
+      if (pattern.test(hostname)) {
+        return { safe: false, reason: 'Private/internal URLs are not allowed' }
+      }
+    }
+
+    return { safe: true, url: parsed.toString() }
+  } catch {
+    return { safe: false, reason: 'Invalid URL' }
+  }
+}


### PR DESCRIPTION
## Summary

### CRITICAL (4 resolved)
- **API keys**: session auth replaces untrusted ownerAddress parameter
- **Alert rules**: session auth + ownership verification (GET/POST/PATCH)
- **Incidents resolve**: session auth + agent ownership check
- **Webhook test**: session auth + SSRF url-validator (blocks private IPs, enforces HTTPS in prod)

### Additional security hardening
- Add session module (HMAC-signed httpOnly cookies, SESSION_SECRET env var)
- Claim endpoint now sets session cookie after SIWE verification
- IPFS upload/upload-file require session auth
- Remove SVG from allowed upload types (XSS prevention)

## Test plan
- [x] 214/214 unit tests passing
- [x] No secrets in code
- [x] Session module mirrors Ayni's proven implementation

Wolfcito 🐾 @akawolfcito