### PR TITLE
fix(security): atomic rate-limit + DB nonces — resolve last 2 HIGHs

### DIFF
--- a/src/app/api/auth/nonce/route.ts
+++ b/src/app/api/auth/nonce/route.ts
@@ -1,20 +1,18 @@
 import { NextResponse } from 'next/server'
+import { supabaseAdmin } from '@/lib/supabase/admin'
 import { generateNonce } from '@/lib/auth/siwe'
 
-// In-memory nonce store (valid for 5 minutes)
-const nonces = new Map<string, number>()
-
-export function GET() {
-  // Clean expired nonces
-  const now = Date.now()
-  for (const [nonce, expiry] of nonces) {
-    if (expiry < now) nonces.delete(nonce)
-  }
-
+export async function GET() {
   const nonce = generateNonce()
-  nonces.set(nonce, now + 5 * 60 * 1000)
+
+  const { error } = await supabaseAdmin
+    .from('nonces')
+    .insert({ nonce })
+
+  if (error) {
+    console.error('Nonce insert error:', error)
+    return NextResponse.json({ error: 'Failed to generate nonce' }, { status: 500 })
+  }
 
   return NextResponse.json({ nonce })
 }
-
-export { nonces }

--- a/src/app/api/claim/route.ts
+++ b/src/app/api/claim/route.ts
@@ -4,7 +4,6 @@ import { createSession } from '@/lib/auth/session'
 import { readAgentOwner } from '@/lib/agent/read'
 import { getChain } from '@/config/chains'
 import { supabaseAdmin } from '@/lib/supabase/admin'
-import { nonces } from '@/app/api/auth/nonce/route'
 import { SiweMessage } from 'siwe'
 
 export async function POST(req: NextRequest) {
@@ -18,15 +17,22 @@ export async function POST(req: NextRequest) {
       )
     }
 
-    // Verify nonce is valid
+    // Verify nonce exists in DB and consume it atomically
     const siweMsg = new SiweMessage(message)
-    if (!nonces.has(siweMsg.nonce)) {
+    const { data: nonceRow, error: nonceErr } = await supabaseAdmin
+      .from('nonces')
+      .delete()
+      .eq('nonce', siweMsg.nonce)
+      .gt('expires_at', new Date().toISOString())
+      .select()
+      .maybeSingle()
+
+    if (nonceErr || !nonceRow) {
       return NextResponse.json(
         { error: 'Invalid or expired nonce' },
         { status: 401 }
       )
     }
-    nonces.delete(siweMsg.nonce)
 
     // Verify SIWE signature
     const result = await verifySiweMessage(message, signature)

--- a/src/lib/api-keys/authenticate.ts
+++ b/src/lib/api-keys/authenticate.ts
@@ -68,29 +68,18 @@ export async function authenticateApiKey(headers: Headers): Promise<AuthResult> 
     }
   }
 
-  // Upsert daily usage counter
+  // Atomic increment via Supabase RPC
   const today = new Date().toISOString().slice(0, 10)
-  const { data: usage } = await supabaseAdmin
-    .from('api_usage_log')
-    .upsert(
-      { api_key_id: keyRow.id, usage_date: today, request_count: 1 },
-      { onConflict: 'api_key_id,usage_date' }
-    )
-    .select('request_count')
-    .single()
+  const { data: rpcResult, error: rpcError } = await supabaseAdmin
+    .rpc('increment_api_usage', { p_api_key_id: keyRow.id, p_usage_date: today })
 
-  // If row already existed, increment
-  if (usage && usage.request_count === 1) {
-    // Fresh insert, count is 1
-  } else if (usage) {
-    await supabaseAdmin
-      .from('api_usage_log')
-      .update({ request_count: usage.request_count + 1 })
-      .eq('api_key_id', keyRow.id)
-      .eq('usage_date', today)
+  if (rpcError) {
+    return {
+      ok: false,
+      error: NextResponse.json({ error: 'Rate limit service unavailable' }, { status: 503 }),
+    }
   }
-
-  const requestCount = usage?.request_count ?? 1
+  const requestCount = rpcResult as number
   const rateLimit = isRateLimited({ requestCount, dailyLimit: keyRow.daily_limit })
 
   if (rateLimit.limited) {

--- a/supabase/migrations/20260314010000_atomic_ratelimit_and_nonces.sql
+++ b/supabase/migrations/20260314010000_atomic_ratelimit_and_nonces.sql
@@ -1,0 +1,29 @@
+-- Atomic rate-limit increment (replaces non-atomic upsert+update pattern)
+create or replace function increment_api_usage(
+  p_api_key_id uuid,
+  p_usage_date date
+)
+returns int
+language plpgsql
+as $$
+declare
+  v_count int;
+begin
+  insert into api_usage_log (api_key_id, usage_date, request_count)
+  values (p_api_key_id, p_usage_date, 1)
+  on conflict (api_key_id, usage_date)
+  do update set request_count = api_usage_log.request_count + 1
+  returning request_count into v_count;
+
+  return v_count;
+end;
+$$;
+
+-- Nonces table (replaces in-memory Map for serverless compatibility)
+create table if not exists nonces (
+  nonce text primary key,
+  expires_at timestamptz not null default (now() + interval '5 minutes'),
+  created_at timestamptz not null default now()
+);
+
+create index if not exists idx_nonces_expires on nonces (expires_at);


### PR DESCRIPTION
## Summary
- Atomic rate-limit via `increment_api_usage` RPC (fixes race condition)
- Fail-closed on RPC error (503 vs bypass)
- DB-backed nonces replace in-memory Map (serverless-safe)
- Claim consumes nonce atomically

Requires: `supabase db push` to apply migration

## Test plan
- [x] 214/214 tests passing
- [x] No secrets

Wolfcito 🐾 @akawolfcito