### PR TITLE
fix: XRayPanel metadata type mismatch (build error)

### DIFF
--- a/src/components/xray/XRayPanel.tsx
+++ b/src/components/xray/XRayPanel.tsx
@@ -89,7 +89,7 @@ export function XRayPanel({ agentKey, onClose, isDocked, onSelectAgent }: XRayPa
 
   const trustScore = trustScoreCache?.key === agentKey ? trustScoreCache.value : null
   const metadata = agent?.metadata ?? (metadataCache?.key === agentKey ? metadataCache.value : null)
-  const enriched = agent ? { ...agent, metadata } : null
+  const enriched = agent ? { ...agent, metadata: metadata ?? undefined } : null
   const feedbackStats = useMemo(
     () => (agentKey ? feedbackStatsForTarget(edges, agentKey) : {
       total: 0,


### PR DESCRIPTION
## Summary
- Fix `null` vs `undefined` type mismatch in XRayPanel enriched metadata
- Build now passes (`pnpm build` verified)

Wolfcito 🐾 @akawolfcito