### PR TITLE
fix: replace 13 ghost tokens from DS v1.1 rename

### DIFF
--- a/src/components/agent/AgentCertificateActions.tsx
+++ b/src/components/agent/AgentCertificateActions.tsx
@@ -57,7 +57,7 @@ export function AgentCertificateActions({ chainId, agentId, agentName }: Props) 
 
       <button
         onClick={handleShare}
-        className="border border-text-primary bg-text-primary px-4 py-1.5 text-xs font-bold text-background hover:bg-transparent hover:text-foreground transition-colors"
+        className="border border-foreground bg-foreground px-4 py-1.5 text-xs font-bold text-background hover:bg-transparent hover:text-foreground transition-colors"
       >
         Share Certificate
       </button>

--- a/src/components/console/IncidentBadge.tsx
+++ b/src/components/console/IncidentBadge.tsx
@@ -16,7 +16,7 @@ export function IncidentBadge() {
   if (count === 0) return null
 
   return (
-    <span className="inline-flex items-center justify-center w-4 h-4 text-[9px] font-bold bg-critical text-white rounded-full">
+    <span className="inline-flex items-center justify-center w-4 h-4 text-[9px] font-bold bg-danger text-white rounded-full">
       {count > 9 ? '9+' : count}
     </span>
   )

--- a/src/components/feed/CertificateStation.tsx
+++ b/src/components/feed/CertificateStation.tsx
@@ -193,14 +193,14 @@ function StationContent({
           <button
             onClick={handleShare}
             disabled={!agent}
-            className="flex-1 border border-text-primary bg-text-primary px-4 py-2.5 text-sm font-bold text-background hover:bg-transparent hover:text-foreground transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+            className="flex-1 border border-foreground bg-foreground px-4 py-2.5 text-sm font-bold text-background hover:bg-transparent hover:text-foreground transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
           >
             Share Certificate
           </button>
           <button
             onClick={handleDownload}
             disabled={!agent}
-            className="border border-border px-3 py-2.5 text-sm text-foreground-muted hover:text-foreground hover:border-text-primary transition-colors disabled:opacity-40"
+            className="border border-border px-3 py-2.5 text-sm text-foreground-muted hover:text-foreground hover:border-foreground transition-colors disabled:opacity-40"
             title="Download PNG"
           >
             ⬇

--- a/src/components/xray/ShareButton.tsx
+++ b/src/components/xray/ShareButton.tsx
@@ -24,7 +24,7 @@ export function ShareButton({ agent }: { agent: AgentSummary }) {
       <div className="flex gap-2">
         <button
           onClick={() => setOpen(!open)}
-          className="border border-text-primary bg-text-primary px-4 py-1.5 text-xs font-bold text-background hover:bg-transparent hover:text-foreground transition-colors"
+          className="border border-foreground bg-foreground px-4 py-1.5 text-xs font-bold text-background hover:bg-transparent hover:text-foreground transition-colors"
         >
           Share Certificate
         </button>

--- a/src/components/xray/TapePanel.tsx
+++ b/src/components/xray/TapePanel.tsx
@@ -83,7 +83,7 @@ export function TapePanel({ onSelectAgent }: TapePanelProps) {
                 onClick={() => setFilter(key)}
                 className={`px-2 py-1 text-[11px] uppercase border transition-colors ${
                   filter === key
-                    ? 'border-text-primary bg-text-primary text-background'
+                    ? 'border-foreground bg-foreground text-background'
                     : 'border-border text-foreground-secondary hover:text-foreground hover:border-border-bright'
                 }`}
               >

--- a/src/components/xray/XRayPanel.tsx
+++ b/src/components/xray/XRayPanel.tsx
@@ -211,7 +211,7 @@ export function XRayPanel({ agentKey, onClose, isDocked, onSelectAgent }: XRayPa
             {/* Primary CTA — Share Certificate (direct X intent) */}
             <button
               onClick={handleShare}
-              className="w-full border border-text-primary bg-text-primary px-4 py-3 text-sm font-bold text-background hover:bg-transparent hover:text-foreground transition-colors"
+              className="w-full border border-foreground bg-foreground px-4 py-3 text-sm font-bold text-background hover:bg-transparent hover:text-foreground transition-colors"
             >
               Share Certificate
             </button>
@@ -295,7 +295,7 @@ export function XRayPanel({ agentKey, onClose, isDocked, onSelectAgent }: XRayPa
             onClick={() => setTab('inspector')}
             className={`px-2 py-1 text-[11px] uppercase border transition-colors ${
               tab === 'inspector'
-                ? 'border-text-primary bg-text-primary text-background'
+                ? 'border-foreground bg-foreground text-background'
                 : 'border-border text-foreground-secondary hover:text-foreground hover:border-border-bright'
             }`}
           >
@@ -305,7 +305,7 @@ export function XRayPanel({ agentKey, onClose, isDocked, onSelectAgent }: XRayPa
             onClick={() => setTab('tape')}
             className={`px-2 py-1 text-[11px] uppercase border transition-colors ${
               tab === 'tape'
-                ? 'border-text-primary bg-text-primary text-background'
+                ? 'border-foreground bg-foreground text-background'
                 : 'border-border text-foreground-secondary hover:text-foreground hover:border-border-bright'
             }`}
           >
@@ -315,7 +315,7 @@ export function XRayPanel({ agentKey, onClose, isDocked, onSelectAgent }: XRayPa
             onClick={() => setTab('leaders')}
             className={`px-2 py-1 text-[11px] uppercase border transition-colors ${
               tab === 'leaders'
-                ? 'border-text-primary bg-text-primary text-background'
+                ? 'border-foreground bg-foreground text-background'
                 : 'border-border text-foreground-secondary hover:text-foreground hover:border-border-bright'
             }`}
           >
@@ -352,7 +352,7 @@ export function XRayPanel({ agentKey, onClose, isDocked, onSelectAgent }: XRayPa
               onClick={() => setTab('inspector')}
               className={`px-2 py-1 text-[11px] uppercase border transition-colors ${
                 tab === 'inspector'
-                  ? 'border-text-primary bg-text-primary text-background'
+                  ? 'border-foreground bg-foreground text-background'
                   : 'border-border text-foreground-secondary hover:text-foreground hover:border-border-bright'
               }`}
             >
@@ -362,7 +362,7 @@ export function XRayPanel({ agentKey, onClose, isDocked, onSelectAgent }: XRayPa
               onClick={() => setTab('tape')}
               className={`px-2 py-1 text-[11px] uppercase border transition-colors ${
                 tab === 'tape'
-                  ? 'border-text-primary bg-text-primary text-background'
+                  ? 'border-foreground bg-foreground text-background'
                   : 'border-border text-foreground-secondary hover:text-foreground hover:border-border-bright'
               }`}
             >
@@ -372,7 +372,7 @@ export function XRayPanel({ agentKey, onClose, isDocked, onSelectAgent }: XRayPa
               onClick={() => setTab('leaders')}
               className={`px-2 py-1 text-[11px] uppercase border transition-colors ${
                 tab === 'leaders'
-                  ? 'border-text-primary bg-text-primary text-background'
+                  ? 'border-foreground bg-foreground text-background'
                   : 'border-border text-foreground-secondary hover:text-foreground hover:border-border-bright'
               }`}
             >


### PR DESCRIPTION
## Summary

Found 13 broken Tailwind class references left over from the token rename in DS v1.1:
- `border-text-primary` / `bg-text-primary` → `border-foreground` / `bg-foreground` (12 uses in 5 files)
- `bg-critical` → `bg-danger` (1 use in IncidentBadge)

These ghost tokens resolved to nothing, making buttons invisible and the incident badge unstyled.

## Test plan
- [ ] "Share Certificate" button visible (white bg, black text in dark mode)
- [ ] XRay panel tab filters have visible active state
- [ ] Incident badge shows red circle
- [ ] 253/253 tests passing

Wolfcito 🐾 @akawolfcito