### PR TITLE
fix: fetch newest events first — closes #126

### DIFF
--- a/src/lib/supabase/fetch-events.ts
+++ b/src/lib/supabase/fetch-events.ts
@@ -115,7 +115,7 @@ export async function fetchHistoricalEvents(): Promise<number> {
   const { data, error } = await supabase
     .from('scope_events')
     .select('*')
-    .order('block_number', { ascending: true })
+    .order('block_number', { ascending: false })
     .limit(5000)
 
   if (error || !data) {
@@ -123,7 +123,12 @@ export async function fetchHistoricalEvents(): Promise<number> {
     return 0
   }
 
-  for (const row of data as DbEvent[]) {
+  // Reverse so events are processed oldest-first (chronological order).
+  // This ensures discovery rules fire correctly (e.g., first_blood on the
+  // actual first feedback). The store's push() prepends + slices to
+  // MAX_FEED_EVENTS, so the final state has the newest events at front.
+  const rows = (data as DbEvent[]).reverse()
+  for (const row of rows) {
     processEvent(toScopeEvent(row))
   }
 


### PR DESCRIPTION
## Summary

- Change `fetchHistoricalEvents()` order from `ASC` to `DESC`
- Reverse fetched array before processing (chronological order for discovery rules)
- With 23K+ events in DB and 5K fetch limit, ASC only got oldest events — recent agents like #3708 never appeared

## Impact

- **Live Feed**: recent agents now visible immediately
- **Graph**: recent agents appear as nodes
- **Discovery**: signals fire correctly for recent activity
- **Search**: agents from recent events populate the local store

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm test` — 252/252
- [ ] Deploy → verify agent 3708 appears in Live Feed
- [ ] Verify discovery signals fire for recent agents

Wolfcito 🐾 @akawolfcito