### PR TITLE
fix: SearchModal Supabase fallback — closes #127

### DIFF
--- a/src/components/search/SearchModal.tsx
+++ b/src/components/search/SearchModal.tsx
@@ -4,7 +4,9 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { motion, AnimatePresence } from 'framer-motion'
 import { useAgentStore } from '@/stores/agents'
+import { searchAgents } from '@/lib/supabase/search-agents'
 import { SearchResult } from './SearchResult'
+import type { AgentSummary } from '@/types/agents'
 
 const MAX_RESULTS = 20
 
@@ -18,9 +20,11 @@ export function SearchModal({ open, onClose }: SearchModalProps) {
   const inputRef = useRef<HTMLInputElement>(null)
   const [query, setQuery] = useState('')
   const [activeIndex, setActiveIndex] = useState(0)
+  const [remoteResults, setRemoteResults] = useState<AgentSummary[]>([])
+  const [searching, setSearching] = useState(false)
   const agents = useAgentStore((s) => s.agents)
 
-  const results = useMemo(() => {
+  const localResults = useMemo(() => {
     const all = Array.from(agents.values())
     if (!query.trim()) return all.slice(0, MAX_RESULTS)
     const q = query.toLowerCase()
@@ -33,6 +37,26 @@ export function SearchModal({ open, onClose }: SearchModalProps) {
       )
       .slice(0, MAX_RESULTS)
   }, [agents, query])
+
+  // Fallback to Supabase when local search has no results
+  useEffect(() => {
+    const q = query.trim()
+    if (!q || localResults.length > 0) {
+      setRemoteResults([])
+      return
+    }
+
+    const timer = setTimeout(async () => {
+      setSearching(true)
+      const results = await searchAgents(q, MAX_RESULTS)
+      setRemoteResults(results)
+      setSearching(false)
+    }, 300)
+
+    return () => clearTimeout(timer)
+  }, [query, localResults.length])
+
+  const results = localResults.length > 0 ? localResults : remoteResults
 
   useEffect(() => {
     setActiveIndex(0)
@@ -134,7 +158,7 @@ export function SearchModal({ open, onClose }: SearchModalProps) {
             <div className="max-h-80 overflow-y-auto">
               {results.length === 0 ? (
                 <div className="px-4 py-8 text-center font-mono text-xs text-text-muted">
-                  No agents found
+                  {searching ? 'Searching...' : query.trim() ? 'No agents found' : 'Type to search'}
                 </div>
               ) : (
                 results.map((agent, i) => (

--- a/src/lib/supabase/search-agents.ts
+++ b/src/lib/supabase/search-agents.ts
@@ -1,0 +1,55 @@
+import { supabase } from './client'
+import type { AgentSummary } from '@/types/agents'
+
+type DbAgent = {
+  chain_id: number
+  agent_id: number
+  owner: string
+  uri: string
+  feedback_count: number
+  positive_count: number
+  negative_count: number
+  first_seen: string | null
+}
+
+function toAgentSummary(row: DbAgent): AgentSummary {
+  return {
+    agentId: row.agent_id,
+    chainId: row.chain_id,
+    owner: row.owner ?? '',
+    agentURI: row.uri ?? '',
+    feedbackCount: row.feedback_count ?? 0,
+    positiveFeedback: row.positive_count ?? 0,
+    negativeFeedback: row.negative_count ?? 0,
+    lastEventBlock: 0,
+    registeredAt: row.first_seen ? new Date(row.first_seen).getTime() : undefined,
+  }
+}
+
+export async function searchAgents(query: string, limit = 20): Promise<AgentSummary[]> {
+  if (!supabase || !query.trim()) return []
+
+  const q = query.trim()
+  const isNumeric = /^\d+$/.test(q)
+
+  if (isNumeric) {
+    const { data, error } = await supabase
+      .from('agents')
+      .select('*')
+      .eq('agent_id', Number(q))
+      .limit(limit)
+
+    if (error || !data) return []
+    return (data as DbAgent[]).map(toAgentSummary)
+  }
+
+  // Text search: try owner address prefix or use ilike on metadata
+  const { data, error } = await supabase
+    .from('agents')
+    .select('*')
+    .or(`owner.ilike.%${q}%,uri.ilike.%${q}%`)
+    .limit(limit)
+
+  if (error || !data) return []
+  return (data as DbAgent[]).map(toAgentSummary)
+}


### PR DESCRIPTION
## Summary

- SearchModal now queries Supabase `agents` table when local store has no results
- Debounced 300ms to avoid spamming on each keystroke
- Numeric queries (`3708`) match `agent_id` exactly
- Text queries match `owner` or `uri` with ilike
- Shows "Searching..." state during remote fetch

## Files

| File | What |
|------|------|
| `search-agents.ts` | New: Supabase agent search helper |
| `SearchModal.tsx` | Add remote fallback + searching state |

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm test` — 252/252
- [x] Search "3708" finds agent via Supabase fallback
- [x] Local results still prioritized (no unnecessary fetches)

Wolfcito 🐾 @akawolfcito