### PR TITLE
refactor: Share on X primary action across all surfaces

### DIFF
--- a/docs/superpowers/plans/2026-04-08-share-hierarchy.md
+++ b/docs/superpowers/plans/2026-04-08-share-hierarchy.md
@@ -1,0 +1,445 @@
+# Share Hierarchy Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make "Share on X" the primary action and native share the secondary across all 6 share surfaces.
+
+**Architecture:** Pure UI refactor — reorder buttons, change labels, remove dropdowns. No new logic. All existing functions from `src/lib/share.ts` are reused as-is.
+
+**Tech Stack:** Next.js 16 (React), TypeScript, Tailwind CSS
+
+**Spec:** `docs/superpowers/specs/2026-04-08-share-hierarchy-design.md`
+
+---
+
+## File Map
+
+| Action | File | Change |
+|--------|------|--------|
+| Modify | `src/components/agent/AgentCertificateActions.tsx` | Add "Share on X" primary, demote "Share Certificate" to "Share", keep "Download" labeled |
+| Modify | `src/components/feed/CertificateStation.tsx` | Swap button order, remove "Share on X →" link |
+| Modify | `src/components/xray/XRayPanel.tsx` | Replace dropdown with "Share" button, add Web Share logic |
+| Modify | `src/components/xray/ShareButton.tsx` | Remove dropdown, make direct "Share on X" button |
+| Modify | `src/components/feed/FeedLine.tsx` | Add `title="Share on X"` tooltip |
+| Modify | `src/app/agent/[chain]/[id]/page.tsx` | Remove standalone "Share on X" link (now in AgentCertificateActions) |
+
+---
+
+### Task 1: Update AgentCertificateActions
+
+**Files:**
+- Modify: `src/components/agent/AgentCertificateActions.tsx`
+
+- [ ] **Step 1: Add X intent imports**
+
+Add `buildXIntentUrl` and `buildCertificateShareText` to the imports at the top of the file:
+
+```tsx
+import { shareCertificate, buildXIntentUrl, buildCertificateShareText } from '@/lib/share'
+```
+
+- [ ] **Step 2: Add handleShareX function**
+
+Add this function after the existing `handleDownload` function (after line 50):
+
+```tsx
+function handleShareX() {
+  window.open(
+    buildXIntentUrl(buildCertificateShareText({ chainId, agentId, name: agentName ?? undefined })),
+    '_blank',
+  )
+}
+```
+
+- [ ] **Step 3: Replace button layout**
+
+Replace the two buttons (lines 58-71) with the new three-button layout:
+
+```tsx
+<button
+  onClick={handleShareX}
+  className="bg-accent px-4 py-1.5 text-xs font-mono font-bold text-white hover:opacity-90 transition-opacity"
+>
+  Share on X
+</button>
+
+<button
+  onClick={handleShare}
+  className="border border-border bg-surface px-3 py-1.5 text-xs font-mono text-text-secondary hover:bg-surface-hover hover:text-text-primary hover:border-border-bright transition-colors"
+>
+  Share
+</button>
+
+<button
+  onClick={handleDownload}
+  className="border border-border bg-surface px-3 py-1.5 text-xs font-mono text-text-secondary hover:bg-surface-hover hover:text-text-primary hover:border-border-bright transition-colors"
+>
+  Download
+</button>
+```
+
+- [ ] **Step 4: Verify build**
+
+```bash
+cd /Users/wolfcito/development/BLCKCHN/GOOD_WOLF_LABS/akawolfcito/denlabs/denscope && pnpm build
+```
+
+Expected: Build succeeds.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/wolfcito/development/BLCKCHN/GOOD_WOLF_LABS/akawolfcito/denlabs/denscope && git add src/components/agent/AgentCertificateActions.tsx && git commit -m "refactor: AgentCertificateActions — Share on X primary, Share secondary
+
+Wolfcito 🐾 @akawolfcito"
+```
+
+---
+
+### Task 2: Update CertificateStation
+
+**Files:**
+- Modify: `src/components/feed/CertificateStation.tsx`
+
+- [ ] **Step 1: Swap button order in action bar**
+
+In the `StationContent` function, replace the action bar (lines 192-216) with:
+
+```tsx
+<div className="flex items-center gap-2">
+  <button
+    onClick={handleShareX}
+    disabled={!agent}
+    className="flex-1 bg-accent px-4 py-2.5 text-sm font-mono font-bold text-white hover:opacity-90 transition-opacity disabled:opacity-40 disabled:cursor-not-allowed"
+  >
+    Share on X
+  </button>
+  <button
+    onClick={handleShare}
+    disabled={!agent}
+    className="border border-border px-3 py-2.5 text-sm font-mono text-text-secondary hover:text-text-primary hover:border-border-bright transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+    title="Share"
+  >
+    Share
+  </button>
+  <button
+    onClick={handleDownload}
+    disabled={!agent}
+    className="border border-border px-3 py-2.5 text-sm text-text-muted hover:text-text-primary hover:border-text-primary transition-colors disabled:opacity-40"
+    title="Download"
+  >
+    ⬇
+  </button>
+</div>
+```
+
+- [ ] **Step 2: Remove the "Share on X →" link**
+
+Delete lines 209-215 (the `<button onClick={handleShareX}...>Share on X →</button>` below the action bar).
+
+- [ ] **Step 3: Verify build**
+
+```bash
+cd /Users/wolfcito/development/BLCKCHN/GOOD_WOLF_LABS/akawolfcito/denlabs/denscope && pnpm build
+```
+
+Expected: Build succeeds.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/wolfcito/development/BLCKCHN/GOOD_WOLF_LABS/akawolfcito/denlabs/denscope && git add src/components/feed/CertificateStation.tsx && git commit -m "refactor: CertificateStation — Share on X primary, remove secondary link
+
+Wolfcito 🐾 @akawolfcito"
+```
+
+---
+
+### Task 3: Update XRayPanel
+
+**Files:**
+- Modify: `src/components/xray/XRayPanel.tsx`
+
+- [ ] **Step 1: Add imports and state**
+
+Add `shareCertificate` to the imports from `@/lib/share`:
+
+```tsx
+import {
+  buildXIntentUrl,
+  buildCertificateShareText,
+  buildOwnerShareText,
+  shareCertificate,
+} from '@/lib/share'
+```
+
+Add state for share feedback. Find the existing `shareMenuOpen` state declaration and replace it:
+
+```tsx
+const [shareStatus, setShareStatus] = useState<string | null>(null)
+const [copyModalUrl, setCopyModalUrl] = useState<string | null>(null)
+```
+
+- [ ] **Step 2: Add handleNativeShare function**
+
+Add this function after the existing `handleShare` function:
+
+```tsx
+async function handleNativeShare() {
+  if (!shareInput) return
+  try {
+    const certUrl = `/api/certificate/${shareInput.chainId}/${shareInput.agentId}`
+    const res = await fetch(`${certUrl}?format=json`)
+    if (!res.ok) return
+    const data = await res.json()
+    const hash = data.hash as string
+    const state = (data.payload?.state ?? 'insufficient_signal') as ShareCardStateKey
+
+    const result = await shareCertificate({
+      hash,
+      name: shareInput.name ?? null,
+      state,
+      lang: 'en',
+    })
+
+    if (result === 'copied') {
+      setShareStatus('Link copied!')
+      setTimeout(() => setShareStatus(null), 2000)
+    } else if (result === 'modal') {
+      setCopyModalUrl(`${window.location.origin}/verify/${hash}`)
+    }
+  } catch { /* silently fail */ }
+}
+```
+
+- [ ] **Step 3: Remove toggleShareMenu function**
+
+Delete the `toggleShareMenu` function (lines 128-130).
+
+- [ ] **Step 4: Replace share buttons in certificate content**
+
+Replace the "Share Certificate" button and "More share options..." dropdown (lines 211-240) with:
+
+```tsx
+{/* Primary CTA — Share on X */}
+<button
+  onClick={handleShare}
+  className="w-full bg-accent px-4 py-3 text-sm font-mono font-bold text-white hover:opacity-90 transition-opacity"
+>
+  Share on X
+</button>
+
+{/* Secondary — Native Share */}
+{shareStatus && (
+  <p className="text-xs text-accent font-mono text-center">{shareStatus}</p>
+)}
+<button
+  onClick={handleNativeShare}
+  className="w-full border border-border bg-surface px-4 py-2.5 text-sm font-mono text-text-secondary hover:bg-surface-hover hover:text-text-primary hover:border-border-bright transition-colors"
+>
+  Share
+</button>
+```
+
+- [ ] **Step 5: Update empty state button text**
+
+Change the disabled button text at line 146 from "Share Certificate" to "Share on X".
+
+- [ ] **Step 6: Add copy modal fallback**
+
+Add the copy modal before the closing `</>` of `certificateContent`, after the "View Full Report" link:
+
+```tsx
+{copyModalUrl && (
+  <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50" onClick={() => setCopyModalUrl(null)}>
+    <div className="bg-bg border border-border p-4 rounded-lg max-w-sm w-full mx-4" onClick={(e) => e.stopPropagation()}>
+      <p className="text-xs text-text-muted mb-2 font-mono">Copy this link:</p>
+      <input
+        type="text"
+        readOnly
+        value={copyModalUrl}
+        className="w-full bg-surface border border-border px-3 py-2 text-sm font-mono text-text-primary rounded"
+        onFocus={(e) => e.target.select()}
+      />
+      <button onClick={() => setCopyModalUrl(null)} className="mt-3 w-full text-xs text-text-muted hover:text-text-primary font-mono">
+        Close
+      </button>
+    </div>
+  </div>
+)}
+```
+
+- [ ] **Step 7: Verify build**
+
+```bash
+cd /Users/wolfcito/development/BLCKCHN/GOOD_WOLF_LABS/akawolfcito/denlabs/denscope && pnpm build
+```
+
+Expected: Build succeeds.
+
+- [ ] **Step 8: Commit**
+
+```bash
+cd /Users/wolfcito/development/BLCKCHN/GOOD_WOLF_LABS/akawolfcito/denlabs/denscope && git add src/components/xray/XRayPanel.tsx && git commit -m "refactor: XRayPanel — Share on X primary, remove dropdown
+
+Wolfcito 🐾 @akawolfcito"
+```
+
+---
+
+### Task 4: Simplify ShareButton
+
+**Files:**
+- Modify: `src/components/xray/ShareButton.tsx`
+
+- [ ] **Step 1: Rewrite component**
+
+Replace the entire component with:
+
+```tsx
+'use client'
+
+import type { AgentSummary } from '@/types/agents'
+import {
+  buildXIntentUrl,
+  buildCertificateShareText,
+} from '@/lib/share'
+
+export function ShareButton({ agent }: { agent: AgentSummary }) {
+  const shareInput = {
+    chainId: agent.chainId,
+    agentId: agent.agentId,
+    name: agent.metadata?.name,
+  }
+
+  function handleShareX() {
+    window.open(buildXIntentUrl(buildCertificateShareText(shareInput)), '_blank')
+  }
+
+  return (
+    <div className="flex gap-2">
+      <button
+        onClick={handleShareX}
+        className="bg-accent px-4 py-1.5 text-xs font-mono font-bold text-white hover:opacity-90 transition-opacity"
+      >
+        Share on X
+      </button>
+      <a
+        href={`/agent/${agent.chainId}/${agent.agentId}`}
+        className="border border-border bg-surface px-3 py-1.5 text-xs font-mono text-text-secondary hover:bg-surface-hover hover:text-text-primary hover:border-border-bright transition-colors"
+      >
+        View Full Report
+      </a>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: Verify build**
+
+```bash
+cd /Users/wolfcito/development/BLCKCHN/GOOD_WOLF_LABS/akawolfcito/denlabs/denscope && pnpm build
+```
+
+Expected: Build succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/wolfcito/development/BLCKCHN/GOOD_WOLF_LABS/akawolfcito/denlabs/denscope && git add src/components/xray/ShareButton.tsx && git commit -m "refactor: ShareButton — direct Share on X, remove dropdown
+
+Wolfcito 🐾 @akawolfcito"
+```
+
+---
+
+### Task 5: Add tooltip to FeedLine
+
+**Files:**
+- Modify: `src/components/feed/FeedLine.tsx`
+
+- [ ] **Step 1: Add tooltip to desktop share icon**
+
+At line 110, add `title="Share on X"` to the share icon span:
+
+```tsx
+<span
+  role="button"
+  tabIndex={-1}
+  onClick={handleShare}
+  title="Share on X"
+  className="opacity-0 group-hover:opacity-100 transition-opacity text-text-muted hover:text-accent px-2"
+>
+  <ShareIcon />
+</span>
+```
+
+- [ ] **Step 2: Add tooltip to mobile share icon**
+
+At line 128, add `title="Share on X"` to the mobile share icon span:
+
+```tsx
+<span
+  role="button"
+  tabIndex={-1}
+  onClick={handleShare}
+  title="Share on X"
+  className="text-text-muted hover:text-accent shrink-0"
+>
+  <ShareIcon />
+</span>
+```
+
+- [ ] **Step 3: Verify build**
+
+```bash
+cd /Users/wolfcito/development/BLCKCHN/GOOD_WOLF_LABS/akawolfcito/denlabs/denscope && pnpm build
+```
+
+Expected: Build succeeds.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/wolfcito/development/BLCKCHN/GOOD_WOLF_LABS/akawolfcito/denlabs/denscope && git add src/components/feed/FeedLine.tsx && git commit -m "fix: add 'Share on X' tooltip to FeedLine share icons
+
+Wolfcito 🐾 @akawolfcito"
+```
+
+---
+
+### Task 6: Remove duplicate Share on X from Agent Page
+
+**Files:**
+- Modify: `src/app/agent/[chain]/[id]/page.tsx`
+
+- [ ] **Step 1: Remove separator and standalone link**
+
+Remove three elements starting around line 255:
+
+1. The separator span: `<span className="hidden md:inline-block border-l border-border h-5 mx-1" />`
+2. The "Share on X" link (the `<a>` tag from lines 257-264)
+
+Keep the `AgentCertificateActions` component and everything after the deleted link (the `<details>` embed section).
+
+- [ ] **Step 2: Clean up unused imports**
+
+Check if `buildXIntentUrl` and `buildCertificateShareText` are still used elsewhere in the file. If the deleted link was the only usage, remove them from the import statement.
+
+- [ ] **Step 3: Verify build and tests**
+
+```bash
+cd /Users/wolfcito/development/BLCKCHN/GOOD_WOLF_LABS/akawolfcito/denlabs/denscope && pnpm build && pnpm test
+```
+
+Expected: Build succeeds, all tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/wolfcito/development/BLCKCHN/GOOD_WOLF_LABS/akawolfcito/denlabs/denscope && git add src/app/agent/[chain]/[id]/page.tsx && git commit -m "refactor: remove duplicate Share on X from agent page
+
+Now provided by AgentCertificateActions component.
+
+Wolfcito 🐾 @akawolfcito"
+```

--- a/docs/superpowers/specs/2026-04-08-share-hierarchy-design.md
+++ b/docs/superpowers/specs/2026-04-08-share-hierarchy-design.md
@@ -1,0 +1,135 @@
+# Share Hierarchy — "Share on X" Primary, Native Share Secondary
+
+**Date:** 2026-04-08
+**Status:** Approved
+
+## Objective
+
+Replace the current mixed share system with a consistent two-action hierarchy across all surfaces. "Share on X" becomes the primary, intentional distribution action. "Share" (Web Share API) becomes the secondary, general-purpose action. Dropdowns and mixed labeling are eliminated.
+
+## Global Share Rule
+
+All share surfaces follow this hierarchy:
+
+| Priority | Label | Action | Styling |
+|----------|-------|--------|---------|
+| **Primary** | Share on X | `buildXIntentUrl(buildCertificateShareText(...))` | Accent bg (`bg-accent`), white text, bold |
+| **Secondary** | Share | `shareCertificate(...)` (Web Share API → clipboard → modal) | Border/outline, `text-secondary` |
+| **Tertiary** | Download | Download certificate PNG | Icon-only on compact surfaces; labeled button on Agent Dossier |
+
+### Naming Rule
+
+Use exactly these labels everywhere. No variations:
+- "Share on X" (not "Share Certificate", not "Share on X →")
+- "Share" (not "Share Certificate", not "More share options")
+- "Download" (not "Download PNG", not "⬇")
+
+### "I Own This Agent"
+
+Removed from all share flows. This is an owner identity action, not a distribution action. It belongs in the owner console, not in general share UI.
+
+## Changes Per Component
+
+### 1. AgentCertificateActions (`src/components/agent/AgentCertificateActions.tsx`)
+
+**Before:** "Share Certificate" (Web Share, primary) + "Download" (secondary)
+**After:** "Share on X" (primary) + "Share" (secondary) + "Download" (tertiary, labeled button — not icon-only)
+
+The component needs a new prop or import to build the X intent URL. Add `buildXIntentUrl` and `buildCertificateShareText` imports from `@/lib/share`.
+
+New button order:
+```
+[Share on X]  — accent bg, calls window.open(buildXIntentUrl(...))
+[Share]       — outline, calls existing handleShare() (Web Share API)
+[Download]    — outline, calls existing handleDownload()
+```
+
+**Download visibility:** On Agent Dossier, Download stays as a labeled button (not icon-only). This is the page where people arrive by deep link and the certificate matters most. The button should be clearly accessible, just visually subordinate to the two share actions.
+
+The existing copy modal fallback for Web Share API failure stays unchanged.
+
+### 2. CertificateStation (`src/components/feed/CertificateStation.tsx`)
+
+**Before:** "Share Certificate" (Web Share, primary) + ⬇ (download icon) + "Share on X →" (link, secondary)
+**After:** "Share on X" (primary) + "Share" (secondary) + ⬇ (download icon)
+
+In the sticky action bar (`StationContent`, lines 188-216):
+- First button: "Share on X" with accent styling — calls existing `handleShareX()`
+- Second button: "Share" with outline styling — calls existing `handleShare()` (Web Share)
+- Third button: Download icon — calls existing `handleDownload()`
+- Remove the "Share on X →" link below the action bar (line 209-215)
+
+### 3. XRayPanel (`src/components/xray/XRayPanel.tsx`)
+
+**Before:** "Share Certificate" (X intent, primary) + "More share options..." dropdown with "I Own This Agent"
+**After:** "Share on X" (primary) + "Share" (secondary, Web Share API)
+
+Changes at lines 211-240:
+- Replace "Share Certificate" button label with "Share on X" (same `handleShare` click handler — already does X intent)
+- Replace "More share options..." dropdown + "I Own This Agent" with a single "Share" button that calls `shareCertificate()`
+- Remove `shareMenuOpen` state and `toggleShareMenu` function (lines 128-130)
+- Add `shareCertificate` import from `@/lib/share`
+- Add state for share feedback (`shareStatus`, `copyModalUrl`) and the copy modal fallback
+
+Also update the empty state button text at line 146: "Share Certificate" → "Share on X"
+
+### 4. ShareButton (`src/components/xray/ShareButton.tsx`)
+
+**Before:** "Share Certificate" button that opens dropdown with "Share Certificate" + "I Own This Agent"
+**After:** Direct "Share on X" button — no dropdown.
+
+The component simplifies to a single button:
+- Label: "Share on X"
+- Click: `window.open(buildXIntentUrl(buildCertificateShareText(shareInput)), '_blank')`
+- Remove `open` state, dropdown, and "I Own This Agent" link
+- Keep the "View Full Report" link as-is (it's not a share action)
+
+### 5. FeedLine (`src/components/feed/FeedLine.tsx`)
+
+**Before:** Share icon on hover → X intent (no label)
+**After:** No code change needed — already does X intent directly.
+
+**Validation items:**
+- Verify tooltip: add `title="Share on X"` to the share icon span (lines 107-113 desktop, lines 128-135 mobile)
+- Verify icon: the current `ShareIcon` component (lines 50-63) renders a generic share/arrow icon. This is acceptable for a compact hover action — changing to an X logo would be over-engineering for a row-level icon. The tooltip provides disambiguation.
+
+### 6. Agent Page (`src/app/agent/[chain]/[id]/page.tsx`)
+
+**Before:** AgentCertificateActions + separator + standalone "Share on X" link (lines 248-264)
+**After:** Only AgentCertificateActions — which now includes "Share on X" as its primary button.
+
+Remove:
+- The separator span (line 255)
+- The standalone "Share on X" link (lines 257-264)
+
+The updated AgentCertificateActions already provides "Share on X" as primary, so the standalone link becomes redundant.
+
+## Shared Logic
+
+No changes needed to `src/lib/share.ts`. All existing functions are reused:
+- `buildXIntentUrl()` — builds X intent URL
+- `buildCertificateShareText()` — community trust snapshot text
+- `shareCertificate()` — Web Share API with fallback chain
+- `buildOwnerShareText()` — kept in code but no longer surfaced in share UI
+
+## Out of Scope
+
+- OG image generation or certificate rendering
+- Verify page copy button
+- Nav restructure
+- "I Own This Agent" relocation to owner console (separate task)
+- X logo icon in FeedLine (tooltip is sufficient)
+
+## Acceptance Criteria
+
+- [ ] All share surfaces use exactly "Share on X", "Share", "Download" labels
+- [ ] "Share on X" is visually primary (accent bg) in all surfaces
+- [ ] "Share" uses Web Share API with clipboard and modal fallbacks
+- [ ] No dropdowns in any share component
+- [ ] "I Own This Agent" removed from all share flows
+- [ ] Download is a labeled button (not icon-only) on Agent Dossier
+- [ ] Download is icon-only on CertificateStation
+- [ ] FeedLine share icon has `title="Share on X"` tooltip
+- [ ] Agent Page has no duplicate "Share on X" link
+- [ ] All existing tests pass
+- [ ] Build succeeds

--- a/src/app/agent/[chain]/[id]/page.tsx
+++ b/src/app/agent/[chain]/[id]/page.tsx
@@ -3,7 +3,6 @@ import { getChain } from '@/config/chains'
 import { readAgentOwner, readAgentURI } from '@/lib/agent/read'
 import { fetchAgentMetadataServer } from '@/lib/agent/metadata'
 import { EmbedSnippet } from '@/components/shared/EmbedSnippet'
-import { buildXIntentUrl, buildCertificateShareText } from '@/lib/share'
 import { findLatestSnapshot } from '@/lib/supabase/certificate-snapshots'
 import { getAppBaseUrl } from '@/lib/trust/certificate'
 import { AgentCertificateActions } from '@/components/agent/AgentCertificateActions'
@@ -251,17 +250,6 @@ export default async function AgentPage({ params }: Props) {
             agentId={agentId}
             agentName={metadata?.name ?? null}
           />
-
-          <span className="hidden md:inline-block border-l border-border h-5 mx-1" />
-
-          <a
-            href={buildXIntentUrl(buildCertificateShareText({ chainId: chainConfig.id, agentId, name: metadata?.name }))}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="border border-border bg-surface px-3 py-1.5 text-xs font-mono text-text-secondary hover:bg-surface-hover hover:text-text-primary hover:border-border-bright transition-colors"
-          >
-            Share on X
-          </a>
 
           <details className="relative">
             <summary className="border border-border bg-surface px-3 py-1.5 text-xs font-mono text-text-secondary hover:bg-surface-hover cursor-pointer list-none">

--- a/src/app/explore/page.tsx
+++ b/src/app/explore/page.tsx
@@ -121,7 +121,7 @@ export default function FeedPage() {
         </div>
         <div className="bg-surface border-border px-4 py-2">
           <p className="text-[10px] font-mono uppercase tracking-widest text-text-muted">Events</p>
-          <p className="text-sm font-mono text-text-primary">
+          <p className="text-sm font-mono text-text-primary" suppressHydrationWarning>
             {filteredCount !== null ? `${filteredCount} / ${events.length}` : events.length}
           </p>
         </div>

--- a/src/components/agent/AgentCertificateActions.tsx
+++ b/src/components/agent/AgentCertificateActions.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState } from 'react'
-import { shareCertificate } from '@/lib/share'
+import { shareCertificate, buildXIntentUrl, buildCertificateShareText } from '@/lib/share'
 import type { ShareCardStateKey } from '@/lib/trust/share-card-state'
 
 type Props = {
@@ -34,6 +34,13 @@ export function AgentCertificateActions({ chainId, agentId, agentName }: Props) 
     } catch { /* silently fail */ }
   }
 
+  function handleShareX() {
+    window.open(
+      buildXIntentUrl(buildCertificateShareText({ chainId, agentId, name: agentName ?? undefined })),
+      '_blank',
+    )
+  }
+
   async function handleDownload() {
     try {
       const res = await fetch(certUrl)
@@ -56,10 +63,17 @@ export function AgentCertificateActions({ chainId, agentId, agentName }: Props) 
       )}
 
       <button
-        onClick={handleShare}
-        className="border border-text-primary bg-text-primary px-4 py-1.5 text-xs font-mono font-bold text-bg hover:bg-transparent hover:text-text-primary transition-colors"
+        onClick={handleShareX}
+        className="bg-accent px-4 py-1.5 text-xs font-mono font-bold text-white hover:opacity-90 transition-opacity"
       >
-        Share Certificate
+        Share on X
+      </button>
+
+      <button
+        onClick={handleShare}
+        className="border border-border bg-surface px-3 py-1.5 text-xs font-mono text-text-secondary hover:bg-surface-hover hover:text-text-primary hover:border-border-bright transition-colors"
+      >
+        Share
       </button>
 
       <button

--- a/src/components/feed/CertificateStation.tsx
+++ b/src/components/feed/CertificateStation.tsx
@@ -191,28 +191,29 @@ function StationContent({
         )}
         <div className="flex items-center gap-2">
           <button
+            onClick={handleShareX}
+            disabled={!agent}
+            className="flex-1 bg-accent px-4 py-2.5 text-sm font-mono font-bold text-white hover:opacity-90 transition-opacity disabled:opacity-40 disabled:cursor-not-allowed"
+          >
+            Share on X
+          </button>
+          <button
             onClick={handleShare}
             disabled={!agent}
-            className="flex-1 border border-text-primary bg-text-primary px-4 py-2.5 text-sm font-mono font-bold text-bg hover:bg-transparent hover:text-text-primary transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+            className="border border-border px-3 py-2.5 text-sm font-mono text-text-secondary hover:text-text-primary hover:border-border-bright transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+            title="Share"
           >
-            Share Certificate
+            Share
           </button>
           <button
             onClick={handleDownload}
             disabled={!agent}
             className="border border-border px-3 py-2.5 text-sm text-text-muted hover:text-text-primary hover:border-text-primary transition-colors disabled:opacity-40"
-            title="Download PNG"
+            title="Download"
           >
             ⬇
           </button>
         </div>
-        <button
-          onClick={handleShareX}
-          disabled={!agent}
-          className="w-full mt-2 text-xs text-text-muted font-mono hover:text-accent transition-colors disabled:opacity-40"
-        >
-          Share on X →
-        </button>
       </div>
     </div>
   )

--- a/src/components/feed/FeedLine.tsx
+++ b/src/components/feed/FeedLine.tsx
@@ -107,6 +107,7 @@ export function FeedLine({ event, isSelected, onClick }: FeedLineProps) {
           role="button"
           tabIndex={-1}
           onClick={handleShare}
+          title="Share on X"
           className="opacity-0 group-hover:opacity-100 transition-opacity text-text-muted hover:text-accent px-2"
         >
           <ShareIcon />
@@ -129,6 +130,7 @@ export function FeedLine({ event, isSelected, onClick }: FeedLineProps) {
             role="button"
             tabIndex={-1}
             onClick={handleShare}
+            title="Share on X"
             className="text-text-muted hover:text-accent shrink-0"
           >
             <ShareIcon />

--- a/src/components/xray/ShareButton.tsx
+++ b/src/components/xray/ShareButton.tsx
@@ -1,62 +1,36 @@
 'use client'
 
-import { useState } from 'react'
 import type { AgentSummary } from '@/types/agents'
 import {
   buildXIntentUrl,
   buildCertificateShareText,
-  buildOwnerShareText,
 } from '@/lib/share'
 
 export function ShareButton({ agent }: { agent: AgentSummary }) {
-  const [open, setOpen] = useState(false)
   const shareInput = {
     chainId: agent.chainId,
     agentId: agent.agentId,
     name: agent.metadata?.name,
   }
 
-  const secondaryClass =
-    'border border-border bg-surface px-3 py-1.5 text-xs font-mono text-text-secondary hover:bg-surface-hover hover:text-text-primary hover:border-border-bright transition-colors'
+  function handleShareX() {
+    window.open(buildXIntentUrl(buildCertificateShareText(shareInput)), '_blank')
+  }
 
   return (
-    <div className="relative">
-      <div className="flex gap-2">
-        <button
-          onClick={() => setOpen(!open)}
-          className="border border-text-primary bg-text-primary px-4 py-1.5 text-xs font-mono font-bold text-bg hover:bg-transparent hover:text-text-primary transition-colors"
-        >
-          Share Certificate
-        </button>
-        <a
-          href={`/agent/${agent.chainId}/${agent.agentId}`}
-          className={secondaryClass}
-        >
-          View Full Report
-        </a>
-      </div>
-      {open && (
-        <div className="absolute top-full left-0 mt-1 z-50 flex flex-col border border-border-bright bg-surface shadow-lg min-w-[200px]">
-          <a
-            href={buildXIntentUrl(buildCertificateShareText(shareInput))}
-            target="_blank"
-            rel="noopener noreferrer"
-            onClick={() => setOpen(false)}
-            className="px-4 py-2.5 text-xs font-mono text-text-secondary hover:bg-surface-hover hover:text-text-primary transition-colors text-left"
-          >
-            Share Certificate
-          </a>
-          <a
-            href={buildXIntentUrl(buildOwnerShareText(shareInput))}
-            target="_blank"
-            rel="noopener noreferrer"
-            onClick={() => setOpen(false)}
-            className="px-4 py-2.5 text-xs font-mono text-text-secondary hover:bg-surface-hover hover:text-text-primary transition-colors text-left border-t border-border"
-          >
-            I Own This Agent
-          </a>
-        </div>
-      )}
+    <div className="flex gap-2">
+      <button
+        onClick={handleShareX}
+        className="bg-accent px-4 py-1.5 text-xs font-mono font-bold text-white hover:opacity-90 transition-opacity"
+      >
+        Share on X
+      </button>
+      <a
+        href={`/agent/${agent.chainId}/${agent.agentId}`}
+        className="border border-border bg-surface px-3 py-1.5 text-xs font-mono text-text-secondary hover:bg-surface-hover hover:text-text-primary hover:border-border-bright transition-colors"
+      >
+        View Full Report
+      </a>
     </div>
   )
 }

--- a/src/components/xray/XRayPanel.tsx
+++ b/src/components/xray/XRayPanel.tsx
@@ -16,8 +16,9 @@ import { getShareCardState } from '@/lib/trust/share-card-state'
 import {
   buildXIntentUrl,
   buildCertificateShareText,
-  buildOwnerShareText,
+  shareCertificate,
 } from '@/lib/share'
+import type { ShareCardStateKey } from '@/lib/trust/share-card-state'
 import type { AgentMetadata } from '@/types/agents'
 import type { TrustScore } from '@/types/trust-score'
 
@@ -40,7 +41,8 @@ export function XRayPanel({ agentKey, onClose, isDocked, onSelectAgent }: XRayPa
   const [metadataCache, setMetadataCache] = useState<{ key: string; value: AgentMetadata | null } | null>(null)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState(false)
-  const [shareMenuOpen, setShareMenuOpen] = useState(false)
+  const [shareStatus, setShareStatus] = useState<string | null>(null)
+  const [copyModalUrl, setCopyModalUrl] = useState<string | null>(null)
   const [tab, setTab] = useState<'inspector' | 'tape' | 'leaders'>('inspector')
   const [trustScoreCache, setTrustScoreCache] = useState<{ key: string; value: TrustScore | null } | null>(null)
 
@@ -125,8 +127,30 @@ export function XRayPanel({ agentKey, onClose, isDocked, onSelectAgent }: XRayPa
     window.open(buildXIntentUrl(buildCertificateShareText(shareInput)), '_blank')
   }
 
-  function toggleShareMenu() {
-    setShareMenuOpen(!shareMenuOpen)
+  async function handleNativeShare() {
+    if (!shareInput) return
+    try {
+      const certUrl = `/api/certificate/${shareInput.chainId}/${shareInput.agentId}`
+      const res = await fetch(`${certUrl}?format=json`)
+      if (!res.ok) return
+      const data = await res.json()
+      const hash = data.hash as string
+      const state = (data.payload?.state ?? 'insufficient_signal') as ShareCardStateKey
+
+      const result = await shareCertificate({
+        hash,
+        name: shareInput.name ?? null,
+        state,
+        lang: 'en',
+      })
+
+      if (result === 'copied') {
+        setShareStatus('Link copied!')
+        setTimeout(() => setShareStatus(null), 2000)
+      } else if (result === 'modal') {
+        setCopyModalUrl(`${window.location.origin}/verify/${hash}`)
+      }
+    } catch { /* silently fail */ }
   }
 
   // Empty state content
@@ -142,7 +166,7 @@ export function XRayPanel({ agentKey, onClose, isDocked, onSelectAgent }: XRayPa
         disabled
         className="mt-6 w-full border border-border bg-surface px-4 py-3 text-sm font-mono font-bold text-text-muted cursor-not-allowed"
       >
-        Share Certificate
+        Share on X
       </button>
     </div>
   )
@@ -208,36 +232,24 @@ export function XRayPanel({ agentKey, onClose, isDocked, onSelectAgent }: XRayPa
               </div>
             </div>
 
-            {/* Primary CTA — Share Certificate (direct X intent) */}
+            {/* Primary CTA — Share on X */}
             <button
               onClick={handleShare}
-              className="w-full border border-text-primary bg-text-primary px-4 py-3 text-sm font-mono font-bold text-bg hover:bg-transparent hover:text-text-primary transition-colors"
+              className="w-full bg-accent px-4 py-3 text-sm font-mono font-bold text-white hover:opacity-90 transition-opacity"
             >
-              Share Certificate
+              Share on X
             </button>
 
-            {/* Owner share option */}
-            <div className="relative">
-              <button
-                onClick={toggleShareMenu}
-                className="w-full text-center font-mono text-[11px] text-text-muted hover:text-text-secondary transition-colors"
-              >
-                More share options...
-              </button>
-              {shareMenuOpen && (
-                <div className="absolute top-full left-0 right-0 mt-1 z-50 flex flex-col border border-border-bright bg-surface shadow-lg">
-                  <a
-                    href={buildXIntentUrl(buildOwnerShareText(shareInput))}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    onClick={() => setShareMenuOpen(false)}
-                    className="px-4 py-2.5 text-xs font-mono text-text-secondary hover:bg-surface-hover hover:text-text-primary transition-colors text-left"
-                  >
-                    I Own This Agent
-                  </a>
-                </div>
-              )}
-            </div>
+            {/* Secondary — Native Share */}
+            {shareStatus && (
+              <p className="text-xs text-accent font-mono text-center">{shareStatus}</p>
+            )}
+            <button
+              onClick={handleNativeShare}
+              className="w-full border border-border bg-surface px-4 py-2.5 text-sm font-mono text-text-secondary hover:bg-surface-hover hover:text-text-primary hover:border-border-bright transition-colors"
+            >
+              Share
+            </button>
 
             {/* Secondary CTA */}
             <a
@@ -246,6 +258,24 @@ export function XRayPanel({ agentKey, onClose, isDocked, onSelectAgent }: XRayPa
             >
               View Full Report &rarr;
             </a>
+
+            {copyModalUrl && (
+              <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50" onClick={() => setCopyModalUrl(null)}>
+                <div className="bg-bg border border-border p-4 rounded-lg max-w-sm w-full mx-4" onClick={(e) => e.stopPropagation()}>
+                  <p className="text-xs text-text-muted mb-2 font-mono">Copy this link:</p>
+                  <input
+                    type="text"
+                    readOnly
+                    value={copyModalUrl}
+                    className="w-full bg-surface border border-border px-3 py-2 text-sm font-mono text-text-primary rounded"
+                    onFocus={(e) => e.target.select()}
+                  />
+                  <button onClick={() => setCopyModalUrl(null)} className="mt-3 w-full text-xs text-text-muted hover:text-text-primary font-mono">
+                    Close
+                  </button>
+                </div>
+              </div>
+            )}
 
             {/* Micro-data (1 line) */}
             <p className="font-mono text-[10px] text-text-muted truncate">


### PR DESCRIPTION
## Summary
- Make "Share on X" the primary action in all 6 share surfaces
- Demote native Web Share to secondary "Share" button
- Remove dropdowns from ShareButton and XRayPanel
- Remove duplicate "Share on X" link from agent dossier page
- Fix hydration mismatch on filtered event count in /explore

## Changes
- **AgentCertificateActions**: Share on X (primary) + Share (secondary) + Download (tertiary)
- **CertificateStation**: Swap button order, remove "Share on X →" link
- **XRayPanel**: Replace dropdown with direct "Share on X" + "Share" buttons
- **ShareButton**: Remove dropdown, direct "Share on X" button
- **FeedLine**: Add `title="Share on X"` tooltip to share icons
- **Agent Page**: Remove standalone link (now in AgentCertificateActions)

## Test plan
- [x] Build passes (361/361 tests)
- [ ] Visual check: all share surfaces show correct button hierarchy
- [ ] "Share on X" opens X intent with certificate text
- [ ] "Share" triggers Web Share API (or clipboard fallback)
- [ ] Download works on Agent Dossier
- [ ] No hydration warnings on /explore

Wolfcito 🐾 @akawolfcito