### PR TITLE
fix: neutral feedbacks + null owner handling

### DIFF
--- a/src/components/feed/CertificateStation.tsx
+++ b/src/components/feed/CertificateStation.tsx
@@ -143,7 +143,7 @@ function StationContent({
 
             {/* Micro-data (1 line) */}
             <p className="font-mono text-[10px] text-text-muted truncate">
-              Owner {truncAddr(agent.owner)} | +{agent.positiveFeedback} / -{agent.negativeFeedback} | Snapshot {new Date().toISOString().slice(0, 16).replace('T', ' ')} UTC
+              Owner {agent.owner ? truncAddr(agent.owner) : 'Unknown'} | +{agent.positiveFeedback} / -{agent.negativeFeedback} | Snapshot {new Date().toISOString().slice(0, 16).replace('T', ' ')} UTC
             </p>
 
             {error && (

--- a/src/lib/reputation/compute.ts
+++ b/src/lib/reputation/compute.ts
@@ -24,6 +24,7 @@ export function computeTrustScore(input: TrustScoreInput): ComputedScore {
   const {
     feedbackCount,
     positiveCount,
+    negativeCount,
     firstSeen,
     lastSeen,
     openCriticalIncidents,
@@ -42,7 +43,9 @@ export function computeTrustScore(input: TrustScoreInput): ComputedScore {
     }
   }
 
-  const positiveRatio = positiveCount / feedbackCount
+  // Neutral feedbacks (value=0) should not dilute the positive ratio
+  const ratedCount = positiveCount + negativeCount
+  const positiveRatio = ratedCount > 0 ? positiveCount / ratedCount : 0
 
   let ageScore = 0
   if (firstSeen) {

--- a/supabase/functions/erc8004-poller/index.ts
+++ b/supabase/functions/erc8004-poller/index.ts
@@ -392,7 +392,9 @@ function computeTrustScoreInline(
     return { score: 0, positiveRatio: 0, activityScore: 0, ageScore: 0, incidentPenalty: 0, confidence: 'low' }
   }
 
-  const positiveRatio = positiveCount / feedbackCount
+  // Neutral feedbacks (value=0) should not dilute the positive ratio
+  const ratedCount = positiveCount + negativeCount
+  const positiveRatio = ratedCount > 0 ? positiveCount / ratedCount : 0
 
   let ageScore = 0
   if (firstSeen) {


### PR DESCRIPTION
## Summary
- Trust ratio now excludes neutral feedbacks (value=0) from denominator
- CertificateStation handles null owner without crash
- Poller inline computation updated to match
- 4 SKALE Base agents backfilled with on-chain owner data

## Why
- Neutral feedbacks (value=0) were diluting positive ratio: an agent with 17 positive, 0 negative, 12 neutral got ratio 17/29=0.59 instead of 17/17=1.0
- `feedbackCount` still includes neutrals for confidence level and activity score

## Test plan
- [x] 361/361 tests passing
- [x] Build green
- [x] trust-sdk e2e: 12/12 on Celo Sepolia, 12/12 on SKALE Base

Wolfcito 🐾 @akawolfcito