### PR TITLE
fix: null owner guards across all components

### DIFF
--- a/src/components/auth/ClaimButton.tsx
+++ b/src/components/auth/ClaimButton.tsx
@@ -34,7 +34,7 @@ export function ClaimButton({ chainId, agentId, ownerAddress, onClaimed }: Claim
   }
 
   // Connected but not the owner
-  if (address.toLowerCase() !== ownerAddress.toLowerCase()) {
+  if (!ownerAddress || address.toLowerCase() !== ownerAddress.toLowerCase()) {
     return (
       <p className="text-xs text-text-muted font-mono">
         Connected wallet does not match the on-chain owner of this agent.

--- a/src/components/search/SearchModal.tsx
+++ b/src/components/search/SearchModal.tsx
@@ -47,7 +47,7 @@ export function SearchModal({ open, onClose }: SearchModalProps) {
         (a) =>
           a.agentId.toString().includes(q) ||
           a.metadata?.name?.toLowerCase().includes(q) ||
-          a.owner.toLowerCase().includes(q)
+          a.owner?.toLowerCase().includes(q)
       )
       .slice(0, MAX_RESULTS)
   }, [agents, query, chainId])

--- a/src/components/shared/AddressChip.tsx
+++ b/src/components/shared/AddressChip.tsx
@@ -3,14 +3,15 @@
 import { useState } from 'react'
 import { getChain } from '@/config/chains'
 
-export function AddressChip({ address, chainId }: { address: string; chainId?: number }) {
+export function AddressChip({ address, chainId }: { address: string | null; chainId?: number }) {
   const [copied, setCopied] = useState(false)
+  if (!address) return <span className="font-mono text-xs text-text-muted">Unknown</span>
   const truncated = `${address.slice(0, 6)}...${address.slice(-4)}`
   const chain = chainId ? getChain(chainId) : null
   const explorerUrl = chain ? `${chain.explorer}/address/${address}` : null
 
   function handleCopy() {
-    navigator.clipboard.writeText(address)
+    navigator.clipboard.writeText(address!)
     setCopied(true)
     setTimeout(() => setCopied(false), 1500)
   }

--- a/src/components/xray/XRayPanel.tsx
+++ b/src/components/xray/XRayPanel.tsx
@@ -29,7 +29,8 @@ type XRayPanelProps = {
   onSelectAgent?: (agentKey: string) => void
 }
 
-function truncateAddress(addr: string): string {
+function truncateAddress(addr: string | null): string {
+  if (!addr) return 'Unknown'
   if (addr.length <= 10) return addr
   return `${addr.slice(0, 6)}...${addr.slice(-4)}`
 }

--- a/src/types/agents.ts
+++ b/src/types/agents.ts
@@ -7,7 +7,7 @@ export type AgentMetadata = {
   services: AgentService[]; x402?: boolean
 }
 export type AgentSummary = {
-  agentId: number; chainId: number; owner: string; agentURI: string;
+  agentId: number; chainId: number; owner: string | null; agentURI: string;
   metadata?: AgentMetadata; feedbackCount: number;
   positiveFeedback: number; negativeFeedback: number;
   lastEventBlock: number; registeredAt?: number


### PR DESCRIPTION
## Summary
- `AgentSummary.owner` now `string | null` (matches DB schema)
- AddressChip, SearchModal, XRayPanel, ClaimButton all handle null owner
- TypeScript type change catches any future null-unsafe access at compile time

## Test plan
- [x] 361/361 tests passing
- [x] Build green (TypeScript catches null paths)

Wolfcito 🐾 @akawolfcito