### PR TITLE
fix(red-team): sprint 2 functional hardening

### DIFF
--- a/src/components/console/AlertsPanel.tsx
+++ b/src/components/console/AlertsPanel.tsx
@@ -1,9 +1,11 @@
 // src/components/console/AlertsPanel.tsx
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useAccount } from 'wagmi'
 import { useAlertStore } from '@/stores/alerts'
+import { fetchOwnerAgents, type OwnerProfile } from '@/lib/supabase/owner-profiles'
+import { getChain } from '@/config/chains'
 import type { AlertRule } from '@/types/alerts'
 
 const RULE_LABELS: Record<string, { label: string; description: string }> = {
@@ -19,6 +21,10 @@ const RULE_LABELS: Record<string, { label: string; description: string }> = {
     label: 'Going Cold',
     description: 'Alert when no feedback in 7 days',
   },
+}
+
+function agentKey(agent: Pick<OwnerProfile, 'chain_id' | 'agent_id'>) {
+  return `${agent.chain_id}:${agent.agent_id}`
 }
 
 function RuleToggle({
@@ -53,22 +59,93 @@ function RuleToggle({
 
 export function AlertsPanel() {
   const { address } = useAccount()
-  const { rules, setRules, updateRule } = useAlertStore()
+  const { rules, setRules, updateRule, clear } = useAlertStore()
+  const [agents, setAgents] = useState<OwnerProfile[]>([])
+  const [selectedKey, setSelectedKey] = useState<string | null>(null)
   const [webhookUrl, setWebhookUrl] = useState('')
   const [saving, setSaving] = useState(false)
   const [testing, setTesting] = useState(false)
   const [testResult, setTestResult] = useState<string | null>(null)
-  const [loading, setLoading] = useState(true)
+  const [loadingAgents, setLoadingAgents] = useState(true)
+  const [loadingRules, setLoadingRules] = useState(false)
 
-  // Fetch alert rules
+  const selected = useMemo(
+    () => agents.find((a) => agentKey(a) === selectedKey) ?? null,
+    [agents, selectedKey],
+  )
+
   useEffect(() => {
-    if (!address) return
-    fetch(`/api/alerts/rules?chainId=42220&agentId=0`)
+    if (!address) {
+      setAgents([])
+      setSelectedKey(null)
+      setLoadingAgents(false)
+      clear()
+      return
+    }
+    let cancelled = false
+    setLoadingAgents(true)
+    fetchOwnerAgents(address)
+      .then((data) => {
+        if (cancelled) return
+        setAgents(data)
+        setSelectedKey(data[0] ? agentKey(data[0]) : null)
+        setLoadingAgents(false)
+      })
+      .catch(() => {
+        if (cancelled) return
+        setLoadingAgents(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [address, clear])
+
+  useEffect(() => {
+    if (!selected) {
+      clear()
+      setWebhookUrl('')
+      return
+    }
+    let cancelled = false
+    setLoadingRules(true)
+    setTestResult(null)
+
+    const qs = new URLSearchParams({
+      chainId: String(selected.chain_id),
+      agentId: String(selected.agent_id),
+    })
+
+    fetch(`/api/alerts/rules?${qs.toString()}`)
       .then((r) => r.json())
-      .then(({ rules: data }) => {
-        // Note: rules might not exist yet, that's OK
-        if (data && data.length > 0) {
-          setRules(data.map((r: Record<string, unknown>) => ({
+      .then(async ({ rules: data, error }) => {
+        if (cancelled) return
+        if (error) {
+          clear()
+          setWebhookUrl('')
+          setLoadingRules(false)
+          return
+        }
+
+        let rows = Array.isArray(data) ? data : []
+
+        if (rows.length === 0) {
+          const res = await fetch('/api/alerts/rules', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              chainId: selected.chain_id,
+              agentId: selected.agent_id,
+            }),
+          })
+          if (res.ok) {
+            const created = await res.json()
+            rows = Array.isArray(created.rules) ? created.rules : []
+          }
+          if (cancelled) return
+        }
+
+        setRules(
+          rows.map((r: Record<string, unknown>) => ({
             id: r.id,
             ownerAddress: r.owner_address,
             chainId: r.chain_id,
@@ -78,34 +155,52 @@ export function AlertsPanel() {
             webhookUrl: r.webhook_url,
             createdAt: r.created_at,
             updatedAt: r.updated_at,
-          })))
-          const url = data.find((r: Record<string, unknown>) => r.webhook_url)?.webhook_url
-          if (url) setWebhookUrl(url as string)
-        }
-        setLoading(false)
+          })) as AlertRule[],
+        )
+        const existing = rows.find((r: Record<string, unknown>) => r.webhook_url)?.webhook_url
+        setWebhookUrl(typeof existing === 'string' ? existing : '')
+        setLoadingRules(false)
       })
-      .catch(() => setLoading(false))
-  }, [address, setRules])
+      .catch(() => {
+        if (cancelled) return
+        clear()
+        setLoadingRules(false)
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [selected, setRules, clear])
 
   async function handleToggle(ruleId: string, enabled: boolean) {
+    const previous = rules.find((r) => r.id === ruleId)?.enabled
     updateRule(ruleId, { enabled })
-    await fetch('/api/alerts/rules', {
+    const res = await fetch('/api/alerts/rules', {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ ruleId, enabled }),
     })
+    if (!res.ok && typeof previous === 'boolean') {
+      updateRule(ruleId, { enabled: previous })
+    }
   }
 
   async function handleSaveWebhook() {
+    if (!selected) return
     setSaving(true)
-    for (const rule of rules) {
-      await fetch('/api/alerts/rules', {
-        method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ ruleId: rule.id, webhookUrl }),
-      })
-    }
+    setTestResult(null)
+    const results = await Promise.all(
+      rules.map((rule) =>
+        fetch('/api/alerts/rules', {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ ruleId: rule.id, webhookUrl }),
+        }).then((r) => r.ok),
+      ),
+    )
+    const allOk = results.every(Boolean)
     setSaving(false)
+    setTestResult(allOk ? 'Webhook saved' : 'Save failed on one or more rules')
   }
 
   async function handleTestWebhook() {
@@ -126,7 +221,7 @@ export function AlertsPanel() {
     setTesting(false)
   }
 
-  if (loading) {
+  if (loadingAgents) {
     return (
       <div className="bg-surface border border-border p-5 space-y-4">
         <div className="h-3 w-24 bg-border rounded animate-pulse" />
@@ -143,7 +238,7 @@ export function AlertsPanel() {
     )
   }
 
-  if (rules.length === 0) {
+  if (agents.length === 0) {
     return (
       <div className="bg-surface border border-border p-5">
         <p className="text-xs text-text-muted font-mono">
@@ -155,15 +250,59 @@ export function AlertsPanel() {
 
   return (
     <div className="bg-surface border border-border p-5 space-y-4">
-      <h2 className="text-xs text-text-muted uppercase tracking-wider font-mono">
-        Alert Rules
-      </h2>
-
-      <div className="divide-y divide-border">
-        {rules.map((rule) => (
-          <RuleToggle key={rule.id} rule={rule} onToggle={handleToggle} />
-        ))}
+      <div className="flex items-center justify-between gap-3">
+        <h2 className="text-xs text-text-muted uppercase tracking-wider font-mono">
+          Alert Rules
+        </h2>
+        {agents.length > 1 && (
+          <label className="flex items-center gap-2 text-[10px] font-mono text-text-muted">
+            <span className="uppercase tracking-wider">Agent</span>
+            <select
+              value={selectedKey ?? ''}
+              onChange={(e) => setSelectedKey(e.target.value)}
+              className="bg-bg border border-border px-2 py-1 text-xs font-mono text-text-primary focus:border-accent/50 focus:outline-none"
+            >
+              {agents.map((agent) => {
+                const chain = getChain(agent.chain_id)
+                return (
+                  <option key={agentKey(agent)} value={agentKey(agent)}>
+                    #{agent.agent_id} · {chain?.name ?? `Chain ${agent.chain_id}`}
+                  </option>
+                )
+              })}
+            </select>
+          </label>
+        )}
+        {agents.length === 1 && selected && (
+          <span className="text-[10px] font-mono text-text-muted">
+            #{selected.agent_id} · {getChain(selected.chain_id)?.name ?? `Chain ${selected.chain_id}`}
+          </span>
+        )}
       </div>
+
+      {loadingRules ? (
+        <div className="space-y-2">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="flex items-center justify-between py-2 animate-pulse">
+              <div className="space-y-1.5">
+                <div className="h-3 w-28 bg-border rounded" />
+                <div className="h-2.5 w-44 bg-border rounded" />
+              </div>
+              <div className="h-5 w-10 bg-border rounded-full" />
+            </div>
+          ))}
+        </div>
+      ) : rules.length === 0 ? (
+        <p className="text-xs text-text-muted font-mono">
+          No alert rules. They will be created the next time this panel loads.
+        </p>
+      ) : (
+        <div className="divide-y divide-border">
+          {rules.map((rule) => (
+            <RuleToggle key={rule.id} rule={rule} onToggle={handleToggle} />
+          ))}
+        </div>
+      )}
 
       <div className="pt-4 border-t border-border space-y-3">
         <label className="text-xs text-text-muted font-mono block">
@@ -179,7 +318,7 @@ export function AlertsPanel() {
         <div className="flex items-center gap-2">
           <button
             onClick={handleSaveWebhook}
-            disabled={saving}
+            disabled={saving || rules.length === 0}
             className="border border-accent/30 bg-accent/5 px-3 py-1.5 text-xs font-mono text-accent hover:bg-accent/10 transition-colors disabled:opacity-50"
           >
             {saving ? 'Saving...' : 'Save'}

--- a/src/lib/dossier/__tests__/fetch.test.ts
+++ b/src/lib/dossier/__tests__/fetch.test.ts
@@ -20,10 +20,10 @@ describe('fetchDossierData', () => {
       const url = typeof input === 'string' ? input : input.toString()
       for (const [pattern, data] of Object.entries(responses)) {
         if (url.includes(pattern)) {
-          return { json: async () => data } as Response
+          return { ok: true, json: async () => data } as Response
         }
       }
-      return { json: async () => [] } as Response
+      return { ok: true, json: async () => [] } as Response
     })
   }
 
@@ -149,5 +149,24 @@ describe('fetchDossierData', () => {
     const result = await fetchDossierData(42220, 3)
     expect(result.openSybilCount).toBe(3)
     expect(result.resolvedSybilCount).toBe(1)
+  })
+
+  it('returns defaults when Supabase fetch rejects (RPC down)', async () => {
+    globalThis.fetch = vi.fn(async () => {
+      throw new Error('network down')
+    })
+    const result = await fetchDossierData(42220, 1)
+    expect(result.firstSeen).toBeNull()
+    expect(result.totalEvents).toBe(0)
+    expect(result.openSybilCount).toBe(0)
+  })
+
+  it('returns defaults when Supabase responds with 503', async () => {
+    globalThis.fetch = vi.fn(async () => {
+      return { ok: false, status: 503, json: async () => ({}) } as Response
+    })
+    const result = await fetchDossierData(42220, 1)
+    expect(result.firstSeen).toBeNull()
+    expect(result.totalEvents).toBe(0)
   })
 })

--- a/src/lib/dossier/fetch.ts
+++ b/src/lib/dossier/fetch.ts
@@ -30,15 +30,19 @@ async function supabaseFetch(path: string): Promise<unknown> {
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL ?? ''
   const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? ''
 
-  const res = await fetch(`${supabaseUrl}/rest/v1/${path}`, {
-    headers: {
-      apikey: supabaseKey,
-      Authorization: `Bearer ${supabaseKey}`,
-    },
-    next: { revalidate: 60 },
-  })
-
-  return res.json()
+  try {
+    const res = await fetch(`${supabaseUrl}/rest/v1/${path}`, {
+      headers: {
+        apikey: supabaseKey,
+        Authorization: `Bearer ${supabaseKey}`,
+      },
+      next: { revalidate: 60 },
+    })
+    if (!res.ok) return []
+    return res.json()
+  } catch {
+    return []
+  }
 }
 
 export async function fetchDossierData(
@@ -47,24 +51,34 @@ export async function fetchDossierData(
 ): Promise<DossierData> {
   const compositeId = encodeURIComponent(`${chainId}:${agentId}`)
 
-  const [agentRows, allEvents, feedbackEvents, openSybil, resolvedSybil] =
-    await Promise.all([
-      supabaseFetch(
-        `agents?id=eq.${compositeId}&select=first_seen,last_seen,feedback_count,positive_count,negative_count`
-      ),
-      supabaseFetch(
-        `scope_events?chain_id=eq.${chainId}&agent_id=eq.${agentId}&select=kind`
-      ),
-      supabaseFetch(
-        `scope_events?chain_id=eq.${chainId}&agent_id=eq.${agentId}&kind=eq.feedback&select=data`
-      ),
-      supabaseFetch(
-        `incidents?chain_id=eq.${chainId}&agent_id=eq.${agentId}&signal_kind=eq.sybil_cluster&resolved_at=is.null&select=id`
-      ),
-      supabaseFetch(
-        `incidents?chain_id=eq.${chainId}&agent_id=eq.${agentId}&signal_kind=eq.sybil_cluster&resolved_at=not.is.null&select=id`
-      ),
-    ])
+  let agentRows: unknown = []
+  let allEvents: unknown = []
+  let feedbackEvents: unknown = []
+  let openSybil: unknown = []
+  let resolvedSybil: unknown = []
+
+  try {
+    ;[agentRows, allEvents, feedbackEvents, openSybil, resolvedSybil] =
+      await Promise.all([
+        supabaseFetch(
+          `agents?id=eq.${compositeId}&select=first_seen,last_seen,feedback_count,positive_count,negative_count`
+        ),
+        supabaseFetch(
+          `scope_events?chain_id=eq.${chainId}&agent_id=eq.${agentId}&select=kind`
+        ),
+        supabaseFetch(
+          `scope_events?chain_id=eq.${chainId}&agent_id=eq.${agentId}&kind=eq.feedback&select=data`
+        ),
+        supabaseFetch(
+          `incidents?chain_id=eq.${chainId}&agent_id=eq.${agentId}&signal_kind=eq.sybil_cluster&resolved_at=is.null&select=id`
+        ),
+        supabaseFetch(
+          `incidents?chain_id=eq.${chainId}&agent_id=eq.${agentId}&signal_kind=eq.sybil_cluster&resolved_at=not.is.null&select=id`
+        ),
+      ])
+  } catch {
+    return { ...DEFAULTS }
+  }
 
   // Guard: if agent not found, return defaults
   if (!Array.isArray(agentRows) || agentRows.length === 0) {


### PR DESCRIPTION
## Summary

Red Team Sprint 2 — three functional bugs identified in the 2026-04-09 audit.

### AlertsPanel hardcoded agentId=0
`src/components/console/AlertsPanel.tsx` fetched \`/api/alerts/rules?chainId=42220&agentId=0\`, so nobody was ever looking at their real alerts. The API correctly returned 403 (not the owner of agent #0), and the UI silently fell into the empty state.

Now the panel loads claimed agents via \`fetchOwnerAgents(address)\`, auto-selects the first one, renders a dropdown when the user owns more than one, and bootstraps default rules when an agent has none yet.

### /agent/[chain]/[id] SSR crash on RPC / Supabase outage
\`fetchDossierData\` ran five \`supabaseFetch\` calls inside \`Promise.all\` with no error handling. A dropped Supabase response would reject the promise, throw up through the async SSR component, and crash the agent page. Now every fetch returns \`[]\` on failure and the outer function returns safe defaults.

### Optimistic update without rollback
\`AlertsPanel.handleToggle\` previously flipped the UI state and fired PATCH — if PATCH failed, the UI stayed out of sync with the server. Now it snapshots the previous state and reverts on non-ok response.

## Tests

- \`src/lib/dossier/__tests__/fetch.test.ts\`: 2 new cases (network reject, HTTP 503) + all existing mocks updated to include \`ok: true\`.
- Full suite: 363/363 green.
- \`pnpm build\` clean.

## Test plan

- [x] \`pnpm test\` — 363/363
- [x] \`pnpm build\` — passes
- [ ] Manual: visit /console with a wallet that has 0, 1, and 2+ claimed agents — verify empty state / single agent inline label / dropdown respectively.
- [ ] Manual: toggle an alert rule with devtools → Network set to offline — verify the toggle snaps back after the PATCH fails.
- [ ] Manual: point \`NEXT_PUBLIC_SUPABASE_URL\` at a broken host and load /agent/42220/1 — verify page renders with zeroed dossier instead of 500.