### PR TITLE
feat(config): centralize SITE_URL via NEXT_PUBLIC_APP_URL, remove hardcoded denscope.vercel.app

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,6 @@
+# Canonical site URL (required — consumed by certificates, share links, OG, x402, embeds)
+NEXT_PUBLIC_APP_URL=https://www.denscope.xyz
+
 # Celo Mainnet RPC (optional — defaults to forno.celo.org)
 NEXT_PUBLIC_CELO_RPC_URL=https://celo-mainnet.g.alchemy.com/v2/YOUR_API_KEY
 

--- a/src/app/api/alerts/webhook-test/route.ts
+++ b/src/app/api/alerts/webhook-test/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { siteUrl } from '@/config/site'
 import { requireSession } from '@/lib/auth/session'
 import { validateWebhookUrl } from '@/lib/security/url-validator'
 
@@ -31,7 +32,7 @@ export async function POST(req: NextRequest) {
       },
       agent: { chainId: 42220, agentId: 0 },
       timestamp: new Date().toISOString(),
-      consoleUrl: 'https://denscope.vercel.app/console',
+      consoleUrl: `${siteUrl()}/console`,
     }
 
     const res = await fetch(urlCheck.url, {

--- a/src/app/api/og/route.tsx
+++ b/src/app/api/og/route.tsx
@@ -1,6 +1,7 @@
 import { ImageResponse } from 'next/og'
 import { readFile } from 'node:fs/promises'
 import { join } from 'node:path'
+import { siteHost } from '@/config/site'
 
 async function loadAssets() {
   const [interRegular, interBlack, wolfcilloRaw, logoRaw] = await Promise.all([
@@ -147,7 +148,7 @@ export async function GET() {
               background: '#000000',
             }}>
               <span style={{ fontSize: 14, color: '#F0F0F0', fontWeight: 700 }}>
-                denscope.vercel.app
+                {siteHost()}
               </span>
             </div>
 

--- a/src/app/api/v1/agent/[chain]/[id]/score/route.ts
+++ b/src/app/api/v1/agent/[chain]/[id]/score/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { siteUrl } from '@/config/site'
 import { supabaseAdmin } from '@/lib/supabase/admin'
 import { authenticateHybrid, buildHybridHeaders } from '@/lib/x402/middleware'
 import { recordX402Payment } from '@/lib/x402/payments'
@@ -56,7 +57,7 @@ export async function GET(req: NextRequest, { params }: RouteParams) {
         },
         updatedAt: score.updatedAt,
       },
-      formula: 'https://denscope.vercel.app/docs/api#trust-score-formula',
+      formula: `${siteUrl()}/docs/api#trust-score-formula`,
     }, { headers: buildHybridHeaders(auth) })
   }
 
@@ -85,6 +86,6 @@ export async function GET(req: NextRequest, { params }: RouteParams) {
       stats: { feedbackCount: 0, positiveCount: 0, negativeCount: 0, openIncidents: 0 },
       updatedAt: null,
     },
-    formula: 'https://denscope.vercel.app/docs/api#trust-score-formula',
+    formula: `${siteUrl()}/docs/api#trust-score-formula`,
   }, { headers: buildHybridHeaders(auth) })
 }

--- a/src/app/docs/api/page.tsx
+++ b/src/app/docs/api/page.tsx
@@ -24,7 +24,7 @@ export default function ApiDocsPage() {
 
         <Section title="Quick Start">
           <CodeHighlight>{`curl -H "Authorization: Bearer ds_YOUR_KEY" \\
-  https://denscope.vercel.app/api/v1/agent/42220/5/score`}</CodeHighlight>
+  https://www.denscope.xyz/api/v1/agent/42220/5/score`}</CodeHighlight>
           <p className="text-xs text-text-muted font-mono mt-2">
             Get your API key from the Console &rarr; API Keys section.
           </p>
@@ -234,7 +234,7 @@ try {
           </Table>
 
           <h4 className="text-xs text-text-muted uppercase font-mono mt-4 mb-2">Example Request</h4>
-          <CodeHighlight>{`curl -X POST https://denscope.vercel.app/api/v1/trust/evaluate \\
+          <CodeHighlight>{`curl -X POST https://www.denscope.xyz/api/v1/trust/evaluate \\
   -H "Authorization: Bearer ds_..." \\
   -H "Content-Type: application/json" \\
   -d '{"chainId": 42220, "agentId": 5, "preset": "default_safety"}'`}</CodeHighlight>
@@ -303,7 +303,7 @@ console.log(result.evaluation.rationale)`}</CodeHighlight>
 
           <h4 className="text-xs text-text-muted uppercase font-mono mt-4 mb-2">Flow</h4>
           <CodeHighlight>{`# 1. Call without auth -> get 402 with payment instructions
-curl -i https://denscope.vercel.app/api/v1/agent/42220/5/score
+curl -i https://www.denscope.xyz/api/v1/agent/42220/5/score
 # HTTP/2 402
 # PAYMENT-REQUIRED: <base64-encoded JSON>
 
@@ -311,7 +311,7 @@ curl -i https://denscope.vercel.app/api/v1/agent/42220/5/score
 
 # 3. Retry with X-PAYMENT header
 curl -H "X-PAYMENT: <base64-encoded payment>" \\
-  https://denscope.vercel.app/api/v1/agent/42220/5/score
+  https://www.denscope.xyz/api/v1/agent/42220/5/score
 # HTTP/2 200 { score: { value: 85, ... } }`}</CodeHighlight>
 
           <h4 className="text-xs text-text-muted uppercase font-mono mt-4 mb-2">Pricing</h4>

--- a/src/app/embed/agent/[chain]/[id]/page.tsx
+++ b/src/app/embed/agent/[chain]/[id]/page.tsx
@@ -1,4 +1,5 @@
 import { getChain } from '@/config/chains'
+import { siteUrl } from '@/config/site'
 import { readAgentOwner, readAgentURI } from '@/lib/agent/read'
 import { fetchAgentMetadataServer } from '@/lib/agent/metadata'
 
@@ -40,7 +41,7 @@ export default async function EmbedAgentCard({ params }: Props) {
   return (
     <div className="flex h-screen items-center justify-center p-2">
       <a
-        href={`https://denscope.vercel.app/agent/${chainConfig.id}/${agentId}`}
+        href={`${siteUrl()}/agent/${chainConfig.id}/${agentId}`}
         target="_blank"
         rel="noopener noreferrer"
         className="block w-full max-w-[420px] border border-border bg-surface hover:border-border-bright transition-colors"

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next'
 import { Space_Grotesk, Inter, JetBrains_Mono } from 'next/font/google'
 import './globals.css'
+import { siteUrl } from '@/config/site'
 import { Header } from '@/components/layout/Header'
 import { StatusBar } from '@/components/layout/StatusBar'
 import { Analytics } from '@vercel/analytics/next'
@@ -24,6 +25,7 @@ const jetbrainsMono = JetBrains_Mono({
 })
 
 export const metadata: Metadata = {
+  metadataBase: new URL(siteUrl()),
   title: 'DenScope — Trust Infrastructure for Autonomous Agents',
   description:
     'Compute trust signals, verify agent behavior, and expose the results through APIs and certificates.',

--- a/src/components/shared/EmbedSnippet.tsx
+++ b/src/components/shared/EmbedSnippet.tsx
@@ -1,12 +1,13 @@
 'use client'
 
 import { useState } from 'react'
+import { siteUrl } from '@/config/site'
 
 export function EmbedSnippet({ chainId, agentId }: { chainId: number; agentId: number }) {
   const [open, setOpen] = useState(false)
   const [copied, setCopied] = useState(false)
 
-  const snippet = `<iframe src="https://denscope.vercel.app/embed/agent/${chainId}/${agentId}" width="420" height="260" frameborder="0"></iframe>`
+  const snippet = `<iframe src="${siteUrl()}/embed/agent/${chainId}/${agentId}" width="420" height="260" frameborder="0"></iframe>`
 
   function handleCopy() {
     navigator.clipboard.writeText(snippet)

--- a/src/config/__tests__/site.test.ts
+++ b/src/config/__tests__/site.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { siteHost, siteUrl } from '../site'
+
+describe('siteUrl', () => {
+  const ORIGINAL = process.env.NEXT_PUBLIC_APP_URL
+
+  beforeEach(() => {
+    delete process.env.NEXT_PUBLIC_APP_URL
+  })
+
+  afterEach(() => {
+    if (ORIGINAL === undefined) delete process.env.NEXT_PUBLIC_APP_URL
+    else process.env.NEXT_PUBLIC_APP_URL = ORIGINAL
+  })
+
+  it('throws when NEXT_PUBLIC_APP_URL is missing', () => {
+    expect(() => siteUrl()).toThrow(/NEXT_PUBLIC_APP_URL/)
+  })
+
+  it('throws when NEXT_PUBLIC_APP_URL is empty string', () => {
+    process.env.NEXT_PUBLIC_APP_URL = ''
+    expect(() => siteUrl()).toThrow(/NEXT_PUBLIC_APP_URL/)
+  })
+
+  it('returns the env value unchanged when no trailing slash', () => {
+    process.env.NEXT_PUBLIC_APP_URL = 'https://www.denscope.xyz'
+    expect(siteUrl()).toBe('https://www.denscope.xyz')
+  })
+
+  it('strips trailing slash from env value', () => {
+    process.env.NEXT_PUBLIC_APP_URL = 'https://www.denscope.xyz/'
+    expect(siteUrl()).toBe('https://www.denscope.xyz')
+  })
+})
+
+describe('siteHost', () => {
+  const ORIGINAL = process.env.NEXT_PUBLIC_APP_URL
+
+  afterEach(() => {
+    if (ORIGINAL === undefined) delete process.env.NEXT_PUBLIC_APP_URL
+    else process.env.NEXT_PUBLIC_APP_URL = ORIGINAL
+  })
+
+  it('extracts host from URL', () => {
+    process.env.NEXT_PUBLIC_APP_URL = 'https://www.denscope.xyz'
+    expect(siteHost()).toBe('www.denscope.xyz')
+  })
+
+  it('extracts host including subdomain', () => {
+    process.env.NEXT_PUBLIC_APP_URL = 'https://staging.denscope.xyz'
+    expect(siteHost()).toBe('staging.denscope.xyz')
+  })
+})

--- a/src/config/site.ts
+++ b/src/config/site.ts
@@ -1,0 +1,20 @@
+/** Site URL config — single source of truth backed by NEXT_PUBLIC_APP_URL.
+ *  Lazy reads so tests can mutate process.env per case. Throws on missing
+ *  env to fail fast at build/render time instead of silently leaking a
+ *  fallback domain. */
+
+function requireEnv(name: string): string {
+  const value = process.env[name]
+  if (!value) throw new Error(`Missing required env: ${name}`)
+  return value.replace(/\/$/, '')
+}
+
+/** Canonical site URL (https://www.denscope.xyz in production). */
+export function siteUrl(): string {
+  return requireEnv('NEXT_PUBLIC_APP_URL')
+}
+
+/** Host fragment of the canonical URL (www.denscope.xyz). */
+export function siteHost(): string {
+  return new URL(siteUrl()).host
+}

--- a/src/lib/share.ts
+++ b/src/lib/share.ts
@@ -1,4 +1,5 @@
 import { getChain } from '@/config/chains'
+import { siteUrl } from '@/config/site'
 import { getAppBaseUrl } from '@/lib/trust/certificate'
 import { getCertificateLabels, type CertificateLang } from '@/lib/trust/certificate-i18n'
 import type { ShareCardStateKey } from '@/lib/trust/share-card-state'
@@ -59,10 +60,7 @@ export async function shareCertificate(
 }
 
 export function buildAgentPageUrl(chainId: number, agentId: number): string {
-  const origin =
-    typeof window !== 'undefined'
-      ? window.location.origin
-      : 'https://denscope.vercel.app'
+  const origin = typeof window !== 'undefined' ? window.location.origin : siteUrl()
   return `${origin}/agent/${chainId}/${agentId}`
 }
 

--- a/src/lib/trust/__tests__/certificate.test.ts
+++ b/src/lib/trust/__tests__/certificate.test.ts
@@ -144,11 +144,9 @@ describe('truncateHash', () => {
 })
 
 describe('getAppBaseUrl', () => {
-  it('strips trailing slash from env var', () => {
-    const original = process.env.NEXT_PUBLIC_APP_URL
-    process.env.NEXT_PUBLIC_APP_URL = 'https://example.com/'
-    expect(getAppBaseUrl()).toBe('https://example.com')
-    process.env.NEXT_PUBLIC_APP_URL = original
+  it('prefers window.location.origin in browser context', () => {
+    // jsdom test env exposes window.location.origin = http://localhost:3000
+    expect(getAppBaseUrl()).toBe(window.location.origin)
   })
 })
 

--- a/src/lib/trust/certificate.ts
+++ b/src/lib/trust/certificate.ts
@@ -1,3 +1,4 @@
+import { siteUrl } from '@/config/site'
 import type { ShareCardStateKey } from './share-card-state'
 import type { TrustBand, RecommendedAction, RiskLevel, DecisionConfidence, PresetId } from '@/types/evaluation'
 
@@ -147,13 +148,9 @@ export function truncateHash(hash: string): string {
   return `${hash.slice(0, 4)}...${hash.slice(-4)}`
 }
 
-/** Get base URL from env, never hardcode domain */
+/** Get base URL — prefer current browser origin (preview-friendly) and fall
+ *  back to the canonical SITE_URL from env. Throws when both are unavailable. */
 export function getAppBaseUrl(): string {
-  if (process.env.NEXT_PUBLIC_APP_URL) {
-    return process.env.NEXT_PUBLIC_APP_URL.replace(/\/$/, '')
-  }
-  if (typeof window !== 'undefined') {
-    return window.location.origin
-  }
-  return 'https://denscope.vercel.app'
+  if (typeof window !== 'undefined') return window.location.origin
+  return siteUrl()
 }

--- a/src/lib/x402/__tests__/middleware.test.ts
+++ b/src/lib/x402/__tests__/middleware.test.ts
@@ -7,7 +7,7 @@ vi.mock('../config', () => ({
     network: 'eip155:42220',
     assetAddress: '0xUSDC',
     assetName: 'USD Coin',
-    baseUrl: 'https://denscope.vercel.app',
+    baseUrl: 'https://www.denscope.xyz',
     facilitatorUrl: 'https://facilitator.test',
     pricing: { score: 0.001, signals: 0.0005 },
   },

--- a/src/lib/x402/__tests__/payment-required.test.ts
+++ b/src/lib/x402/__tests__/payment-required.test.ts
@@ -7,7 +7,7 @@ vi.mock('../config', () => ({
     network: 'eip155:42220',
     assetAddress: '0xUSDC_ADDRESS',
     assetName: 'USD Coin',
-    baseUrl: 'https://denscope.vercel.app',
+    baseUrl: 'https://www.denscope.xyz',
     facilitatorUrl: 'https://facilitator.ultravioletadao.xyz',
     pricing: { score: 0.001, signals: 0.0005 },
   },
@@ -18,7 +18,7 @@ import { createPaymentRequired } from '../payment-required'
 describe('createPaymentRequired', () => {
   it('generates valid 402 body for score endpoint', () => {
     const { body, header } = createPaymentRequired({
-      resourceUrl: 'https://denscope.vercel.app/api/v1/agent/42220/5/score',
+      resourceUrl: 'https://www.denscope.xyz/api/v1/agent/42220/5/score',
       description: 'Trust score query',
       priceKey: 'score',
     })
@@ -39,7 +39,7 @@ describe('createPaymentRequired', () => {
 
   it('generates correct amount for signals pricing', () => {
     const { body } = createPaymentRequired({
-      resourceUrl: 'https://denscope.vercel.app/api/v1/agent/42220/5/signals',
+      resourceUrl: 'https://www.denscope.xyz/api/v1/agent/42220/5/signals',
       description: 'Signals query',
       priceKey: 'signals',
     })
@@ -59,7 +59,7 @@ describe('createPaymentRequired', () => {
 
   it('header decodes back to the body', () => {
     const { body, header } = createPaymentRequired({
-      resourceUrl: 'https://denscope.vercel.app/api/v1/agent/42220/5/score',
+      resourceUrl: 'https://www.denscope.xyz/api/v1/agent/42220/5/score',
       description: 'Trust score',
       priceKey: 'score',
     })

--- a/src/lib/x402/config.ts
+++ b/src/lib/x402/config.ts
@@ -1,5 +1,7 @@
 /** x402 server config — reads from env vars with Celo mainnet defaults */
 
+import { siteUrl } from '@/config/site'
+
 export const x402Config = {
   /** Wallet that receives USDC payments */
   payTo: process.env.X402_PAY_TO ?? '',
@@ -16,7 +18,7 @@ export const x402Config = {
   assetName: process.env.X402_ASSET_NAME ?? 'USD Coin',
 
   /** Public base URL for resource field */
-  baseUrl: process.env.X402_BASE_URL ?? 'https://denscope.vercel.app',
+  baseUrl: process.env.X402_BASE_URL ?? siteUrl(),
 
   /** UltravioletaDAO facilitator URL */
   facilitatorUrl:

--- a/supabase/functions/erc8004-poller/index.ts
+++ b/supabase/functions/erc8004-poller/index.ts
@@ -15,6 +15,15 @@ import { celo } from 'https://esm.sh/viem@2.23.2/chains'
 
 // --- Config ---
 
+// Canonical site URL for webhook payloads. Missing secret is non-fatal:
+// the poller keeps ingesting but webhook receivers won't get a consoleUrl.
+type DenoGlobal = { env: { get(name: string): string | undefined } }
+const denoRef = (globalThis as unknown as { Deno?: DenoGlobal }).Deno
+const SITE_URL = denoRef?.env.get('DENSCOPE_SITE_URL') ?? null
+if (!SITE_URL) {
+  console.warn('[erc8004-poller] DENSCOPE_SITE_URL secret missing — webhook payloads will omit consoleUrl')
+}
+
 const CHUNK_SIZE = 500
 
 const CHAINS = [
@@ -339,7 +348,7 @@ async function dispatchWebhooks(db: DB, signals: SignalResult[]) {
 
     for (const rule of rules) {
       if (!rule.webhook_url) continue
-      const payload = {
+      const payload: Record<string, unknown> = {
         incident: {
           signalKind: signal.signal_kind,
           severity: signal.severity,
@@ -349,8 +358,8 @@ async function dispatchWebhooks(db: DB, signals: SignalResult[]) {
         },
         agent: { chainId: signal.chain_id, agentId: signal.agent_id },
         timestamp: new Date().toISOString(),
-        consoleUrl: `https://denscope.vercel.app/console`,
       }
+      if (SITE_URL) payload.consoleUrl = `${SITE_URL}/console`
 
       try {
         const res = await fetch(rule.webhook_url, {


### PR DESCRIPTION
## Summary

- Replaces 10 hardcoded `denscope.vercel.app` fallbacks with a single source of truth: `siteUrl()`/`siteHost()` helpers backed by the `NEXT_PUBLIC_APP_URL` env (required, no domain fallback).
- Adds `metadataBase` to root layout so OG image URLs become absolute.
- Edge function `erc8004-poller` reads the `DENSCOPE_SITE_URL` secret with graceful degrade (omits `consoleUrl` from webhook payload if missing — pg_cron won't cascade-fail).
- Domain migration to `www.denscope.xyz` (Vercel redirect 301 catch-all from `denscope.vercel.app` already configured).

## Behavioral changes

| File | Before | After |
|---|---|---|
| `src/lib/trust/certificate.ts` | env -> window.origin -> `.vercel.app` fallback | window.origin -> `siteUrl()` (no fallback) |
| `src/lib/x402/config.ts` | env override or `.vercel.app` | env override or `siteUrl()` |
| `src/lib/share.ts` | SSR fallback `.vercel.app` | SSR uses `siteUrl()` |
| `src/app/layout.tsx` | no `metadataBase` | `metadataBase: new URL(siteUrl())` |
| `src/app/api/og/route.tsx` | text `denscope.vercel.app` | `siteHost()` |
| `src/app/api/alerts/webhook-test/route.ts` | hardcoded console URL | `${siteUrl()}/console` |
| `src/app/api/v1/agent/[chain]/[id]/score/route.ts` | `formula` JSON URL hardcoded | `${siteUrl()}/...` |
| `src/app/embed/agent/[chain]/[id]/page.tsx` | href hardcoded | `${siteUrl()}/...` |
| `src/app/docs/api/page.tsx` | 4 curl snippets show old domain | rewritten to `www.denscope.xyz` |
| `src/components/shared/EmbedSnippet.tsx` | iframe src hardcoded | `siteUrl()` (Next.js inlines `NEXT_PUBLIC_*`) |
| `supabase/functions/erc8004-poller/index.ts` | hardcoded webhook URL | reads `DENSCOPE_SITE_URL` secret, graceful degrade if missing |

## Test plan

- [x] 374/374 vitest passing (368 baseline + 6 new for `siteUrl`/`siteHost`)
- [x] `pnpm build` green
- [x] `pnpm lint`: 0 new errors introduced (56 preexisting unchanged)
- [ ] Deploy ops checklist (post-merge):
  - [ ] Vercel env var `NEXT_PUBLIC_APP_URL` set to the canonical site URL (Production + Preview)
  - [ ] Supabase secret `DENSCOPE_SITE_URL` set via `supabase secrets set ...`
  - [ ] Redeploy edge function via `supabase functions deploy erc8004-poller --no-verify-jwt`
  - [ ] Smoke test verify/og/embed/share/score routes

## Decisions documented

- **No hardcoded fallback in code** — the env is required, throws on missing. Fail fast at build/render time over silently leaking the old domain.
- **Lazy `siteUrl()`** — tests mutate env per-case without module reset.
- **Edge function graceful degrade** — missing secret omits `consoleUrl` from webhook payload, doesn't crash poller (pg_cron protected).
- **Preserves `window.location.origin` client-side** — preview deployments keep their preview URL in share/verify links.

Wolfcito 🐾 @akawolfcito