### PR TITLE
chore(readme): update domain to www.denscope.xyz

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 Real-time ERC-8004 agent explorer with trust scoring, signal detection, and x402 micropayments.
 
-[![Deploy](https://img.shields.io/badge/deploy-vercel-black)](https://denscope.vercel.app)
+[![Deploy](https://img.shields.io/badge/deploy-vercel-black)](https://www.denscope.xyz)
 
-**Live:** [https://denscope.vercel.app](https://denscope.vercel.app)
+**Live:** [https://www.denscope.xyz](https://www.denscope.xyz)
 
 ## Tech Stack
 


### PR DESCRIPTION
## Summary

Updates the badge link and the "Live:" pointer in README to the canonical domain. The legacy URL keeps working via the 301 catch-all redirect already configured in Vercel.

## Test plan

- [x] Renders correctly on GitHub markdown preview
- [x] Both links resolve to the same destination (verified via 301 redirect)

Wolfcito 🐾 @akawolfcito