### PR TITLE
feat(routing): proxy agent.denscope.xyz to Railway via host-based rewrite

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,17 @@
 import type { NextConfig } from "next";
 
+const AGENT_ORIGIN = "https://denscope-agent-production.up.railway.app";
+
 const nextConfig: NextConfig = {
-  /* config options here */
+  async rewrites() {
+    return [
+      {
+        source: "/:path*",
+        destination: `${AGENT_ORIGIN}/:path*`,
+        has: [{ type: "host", value: "agent.denscope.xyz" }],
+      },
+    ];
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary

Routes a new `agent.denscope.xyz` subdomain to the trust advisor service hosted on Railway, using a Next.js rewrite filtered by host header. The main `www.denscope.xyz` traffic is unaffected — only requests landing on the agent subdomain are forwarded.

## Why

- **Brand consistency** — A2A/MCP endpoints under the canonical denscope.xyz domain.
- **Portability** — future host migrations (Railway → Fly → self-hosted) require no agent re-registration on-chain.
- **Provider hiding** — clients don't see `up.railway.app` in the registered metadata.
- **Mainnet promotion** — the SKALE Base mainnet registration (pending) will use the new subdomain URL.

## Test plan

After deploy + adding `agent.denscope.xyz` as a custom domain in Vercel:

```bash
curl -s https://agent.denscope.xyz/.well-known/agent-card.json | jq .name
# expected: "DenScope Trust Advisor"

curl -sI https://agent.denscope.xyz/mcp | head -3
# expected: 200 or 405 (MCP-specific, depends on protocol)

curl -sI https://www.denscope.xyz/api/og | head -3
# expected: 200 — main domain unchanged
```

## Deploy ops (post-merge)

- [ ] Vercel Dashboard → denscope-xr → Settings → Domains → Add `agent.denscope.xyz`
- [ ] Confirm DNS auto-config (Vercel manages it since denscope.xyz is already linked)
- [ ] Run the 3 smoke tests above
- [ ] Update `den-labs/denscope-agent` `AGENT_CONFIG.a2aEndpoint` and `mcpEndpoint` to `https://agent.denscope.xyz/...` in a follow-up PR
- [ ] Re-register the agent on SKALE Base mainnet with the new metadata

Wolfcito 🐾 @akawolfcito