### PR TITLE
fix(trustops): source recent evaluations from evaluation_log

### DIFF
--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -32,8 +32,10 @@ export async function POST(req: NextRequest) {
       )
     }
 
-    // Verify SIWE signature
-    const result = await verifySiweMessage(message, signature)
+    // Verify SIWE signature, bound to the origin that made this request
+    const expectedDomain =
+      req.headers.get('x-forwarded-host') ?? req.headers.get('host') ?? ''
+    const result = await verifySiweMessage(message, signature, expectedDomain)
     if (!result.valid) {
       return NextResponse.json(
         { error: result.error },

--- a/src/app/api/claim/route.ts
+++ b/src/app/api/claim/route.ts
@@ -34,8 +34,10 @@ export async function POST(req: NextRequest) {
       )
     }
 
-    // Verify SIWE signature
-    const result = await verifySiweMessage(message, signature)
+    // Verify SIWE signature, bound to the origin that made this request
+    const expectedDomain =
+      req.headers.get('x-forwarded-host') ?? req.headers.get('host') ?? ''
+    const result = await verifySiweMessage(message, signature, expectedDomain)
     if (!result.valid) {
       return NextResponse.json(
         { error: result.error },

--- a/src/app/api/v1/trust/evaluate/route.ts
+++ b/src/app/api/v1/trust/evaluate/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { authenticateHybrid, buildHybridHeaders } from '@/lib/x402/middleware'
 import { recordX402Payment } from '@/lib/x402/payments'
+import { recordEvaluation } from '@/lib/trustops/log'
 import { composeEvaluation } from '@/lib/evaluation/compose'
 import { isValidPreset } from '@/lib/evaluation/presets'
 import type { PresetId } from '@/types/evaluation'
@@ -45,6 +46,15 @@ export async function POST(req: NextRequest) {
       context: body.context as string | undefined,
       sensitivity: body.sensitivity as 'low' | 'normal' | 'high' | undefined,
       objective: body.objective as string | undefined,
+    })
+
+    // Record evaluation in the audit log (fire-and-forget)
+    recordEvaluation({
+      chainId,
+      agentId,
+      endpoint: ENDPOINT_PATH,
+      preset,
+      authMethod: auth.method === 'x402' ? 'x402' : 'api_key',
     })
 
     // Record x402 payment (fire-and-forget)

--- a/src/components/auth/ClaimButton.tsx
+++ b/src/components/auth/ClaimButton.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react'
 import { useAccount, useSignMessage } from 'wagmi'
-import { createSiweMessage } from '@/lib/auth/siwe'
+import { createSiweMessage, browserSiweOrigin } from '@/lib/auth/siwe'
 import { humanizeError } from '@/lib/errors/humanize'
 import { ConnectButton } from './ConnectButton'
 
@@ -61,7 +61,10 @@ export function ClaimButton({ chainId, agentId, ownerAddress, onClaimed }: Claim
       const { nonce } = await nonceRes.json()
 
       // 2. Create and sign SIWE message
+      const { domain, uri } = browserSiweOrigin()
       const message = createSiweMessage({
+        domain,
+        uri,
         address: address!,
         chainId,
         nonce,

--- a/src/components/auth/ConnectButton.tsx
+++ b/src/components/auth/ConnectButton.tsx
@@ -5,20 +5,22 @@ import { injected } from '@wagmi/connectors'
 import { useEffect, useRef, useCallback } from 'react'
 import { useAuthStore } from '@/stores/auth'
 import { SiweMessage } from 'siwe'
-
-const APP_DOMAIN = process.env.NEXT_PUBLIC_APP_DOMAIN ?? 'localhost:3000'
-const APP_URI = process.env.NEXT_PUBLIC_APP_URL ?? 'http://localhost:3000'
+import { browserSiweOrigin } from '@/lib/auth/siwe'
 
 export function ConnectButton() {
   const { address, isConnected } = useAccount()
   const chainId = useChainId()
-  const { connect } = useConnect()
+  const { connectAsync } = useConnect()
   const { disconnect } = useDisconnect()
   const { signMessageAsync } = useSignMessage()
   const setAddress = useAuthStore((s) => s.setAddress)
+  const setAuthenticated = useAuthStore((s) => s.setAuthenticated)
+  const authenticated = useAuthStore((s) => s.authenticated)
   const authDisconnect = useAuthStore((s) => s.disconnect)
   const signingRef = useRef(false)
 
+  // Sign-in is user-initiated only — never auto-fired on reconnect. Builds the
+  // SIWE message with the live browser origin so wallets pass domain binding.
   const signIn = useCallback(async (addr: string) => {
     if (signingRef.current) return
     signingRef.current = true
@@ -26,11 +28,12 @@ export function ConnectButton() {
       const nonceRes = await fetch('/api/auth/nonce')
       const { nonce } = await nonceRes.json()
 
+      const { domain, uri } = browserSiweOrigin()
       const message = new SiweMessage({
-        domain: APP_DOMAIN,
+        domain,
         address: addr,
         statement: 'Sign in to DenScope',
-        uri: APP_URI,
+        uri,
         version: '1',
         chainId,
         nonce,
@@ -38,28 +41,39 @@ export function ConnectButton() {
 
       const signature = await signMessageAsync({ message })
 
-      await fetch('/api/auth/login', {
+      const res = await fetch('/api/auth/login', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ message, signature }),
       })
+      setAuthenticated(res.ok)
     } catch {
-      // User rejected signature or network error — silent, session just won't be created
+      // User rejected signature or network error — silent, no session created
     } finally {
       signingRef.current = false
     }
-  }, [chainId, signMessageAsync])
+  }, [chainId, signMessageAsync, setAuthenticated])
 
+  // On (re)connect: restore the address for display only. No signature prompt.
   useEffect(() => {
     if (isConnected && address) {
       setAddress(address)
-      signIn(address)
     } else {
       authDisconnect()
     }
-  }, [isConnected, address, setAddress, authDisconnect, signIn])
+  }, [isConnected, address, setAddress, authDisconnect])
 
-  if (isConnected && address) {
+  const handleConnect = useCallback(async () => {
+    try {
+      const result = await connectAsync({ connector: injected() })
+      const addr = result.accounts[0]
+      if (addr) await signIn(addr)
+    } catch {
+      // User dismissed the wallet connection prompt
+    }
+  }, [connectAsync, signIn])
+
+  if (isConnected && address && authenticated) {
     return (
       <div className="flex items-center gap-2">
         <span className="font-mono text-xs text-text-secondary">
@@ -75,9 +89,21 @@ export function ConnectButton() {
     )
   }
 
+  // Connected (e.g. restored on reload) but no session yet — explicit sign-in.
+  if (isConnected && address) {
+    return (
+      <button
+        onClick={() => signIn(address)}
+        className="border border-accent/30 bg-accent/5 px-3 py-1 text-xs font-mono text-accent hover:bg-accent/10 hover:border-accent/50 transition-colors"
+      >
+        Sign in
+      </button>
+    )
+  }
+
   return (
     <button
-      onClick={() => connect({ connector: injected() })}
+      onClick={handleConnect}
       className="border border-accent/30 bg-accent/5 px-3 py-1 text-xs font-mono text-accent hover:bg-accent/10 hover:border-accent/50 transition-colors"
     >
       Connect Wallet

--- a/src/config/site.ts
+++ b/src/config/site.ts
@@ -3,15 +3,17 @@
  *  env to fail fast at build/render time instead of silently leaking a
  *  fallback domain. */
 
-function requireEnv(name: string): string {
-  const value = process.env[name]
+function requireEnv(name: string, value: string | undefined): string {
   if (!value) throw new Error(`Missing required env: ${name}`)
   return value.replace(/\/$/, '')
 }
 
-/** Canonical site URL (https://www.denscope.xyz in production). */
+/** Canonical site URL (https://www.denscope.xyz in production).
+ *  NEXT_PUBLIC_APP_URL is read as a static literal so Next.js inlines it into
+ *  the client bundle — a dynamic process.env[name] access is NOT replaced at
+ *  build time and resolves to undefined in the browser. */
 export function siteUrl(): string {
-  return requireEnv('NEXT_PUBLIC_APP_URL')
+  return requireEnv('NEXT_PUBLIC_APP_URL', process.env.NEXT_PUBLIC_APP_URL)
 }
 
 /** Host fragment of the canonical URL (www.denscope.xyz). */

--- a/src/lib/auth/__tests__/siwe.test.ts
+++ b/src/lib/auth/__tests__/siwe.test.ts
@@ -6,6 +6,8 @@ const CHECKSUM_ADDRESS = '0x1234567890AbcdEF1234567890aBcdef12345678'
 describe('createSiweMessage', () => {
   it('creates a valid SIWE message string', () => {
     const message = createSiweMessage({
+      domain: 'www.denscope.xyz',
+      uri: 'https://www.denscope.xyz',
       address: CHECKSUM_ADDRESS,
       chainId: 42220,
       nonce: 'abc123def456',
@@ -16,13 +18,16 @@ describe('createSiweMessage', () => {
     expect(message).toContain('Claim agent ownership on DenScope')
   })
 
-  it('includes the domain and URI', () => {
+  it('includes the caller-provided domain and URI', () => {
     const message = createSiweMessage({
+      domain: 'www.denscope.xyz',
+      uri: 'https://www.denscope.xyz',
       address: CHECKSUM_ADDRESS,
       chainId: 42220,
       nonce: 'testnonce123',
     })
-    expect(message).toContain('localhost:3000')
+    expect(message).toContain('www.denscope.xyz')
+    expect(message).toContain('https://www.denscope.xyz')
   })
 })
 

--- a/src/lib/auth/__tests__/verify.test.ts
+++ b/src/lib/auth/__tests__/verify.test.ts
@@ -6,7 +6,7 @@ vi.mock('siwe', () => {
   return {
     SiweMessage: class {
       address = '0xTestAddress'
-      domain = 'localhost:3000'
+      domain = 'www.denscope.xyz'
       verify = mockVerify
     },
   }
@@ -19,18 +19,26 @@ describe('verifySiweMessage', () => {
     mockVerify.mockReset()
   })
 
-  it('returns valid true with address on successful verify', async () => {
+  it('returns valid true with address when domain matches and verify succeeds', async () => {
     mockVerify.mockResolvedValue({ success: true })
 
-    const result = await verifySiweMessage('message', '0xsig')
+    const result = await verifySiweMessage('message', '0xsig', 'www.denscope.xyz')
 
     expect(result).toEqual({ valid: true, address: '0xTestAddress' })
+    expect(mockVerify).toHaveBeenCalledWith({ signature: '0xsig', domain: 'www.denscope.xyz' })
+  })
+
+  it('rejects when the message domain does not match the expected (request) domain', async () => {
+    const result = await verifySiweMessage('message', '0xsig', 'evil.example.com')
+
+    expect(result).toEqual({ valid: false, error: 'Domain mismatch' })
+    expect(mockVerify).not.toHaveBeenCalled()
   })
 
   it('returns valid false when verify result.success is false', async () => {
     mockVerify.mockResolvedValue({ success: false })
 
-    const result = await verifySiweMessage('message', '0xsig')
+    const result = await verifySiweMessage('message', '0xsig', 'www.denscope.xyz')
 
     expect(result).toEqual({ valid: false, error: 'Signature verification failed' })
   })
@@ -38,7 +46,7 @@ describe('verifySiweMessage', () => {
   it('returns valid false with error message on exception', async () => {
     mockVerify.mockRejectedValue(new Error('Invalid signature format'))
 
-    const result = await verifySiweMessage('message', '0xsig')
+    const result = await verifySiweMessage('message', '0xsig', 'www.denscope.xyz')
 
     expect(result).toEqual({ valid: false, error: 'Invalid signature format' })
   })

--- a/src/lib/auth/siwe.ts
+++ b/src/lib/auth/siwe.ts
@@ -1,9 +1,11 @@
 import { SiweMessage } from 'siwe'
 
-const DOMAIN = process.env.NEXT_PUBLIC_APP_DOMAIN ?? 'localhost:3000'
-const URI = process.env.NEXT_PUBLIC_APP_URL ?? 'http://localhost:3000'
-
 type CreateMessageParams = {
+  /** Must equal the requesting origin's host (window.location.host) so wallets
+   *  pass their phishing/domain-binding check. */
+  domain: string
+  /** Must equal window.location.origin. */
+  uri: string
   address: string
   chainId: number
   nonce: string
@@ -11,21 +13,28 @@ type CreateMessageParams = {
 }
 
 export function createSiweMessage({
+  domain,
+  uri,
   address,
   chainId,
   nonce,
   statement = 'Sign in to DenScope',
 }: CreateMessageParams): string {
   const message = new SiweMessage({
-    domain: DOMAIN,
+    domain,
     address,
     statement,
-    uri: URI,
+    uri,
     version: '1',
     chainId,
     nonce,
   })
   return message.prepareMessage()
+}
+
+/** Domain + URI bound to the live browser origin. Client-only (reads window). */
+export function browserSiweOrigin(): { domain: string; uri: string } {
+  return { domain: window.location.host, uri: window.location.origin }
 }
 
 export function generateNonce(): string {

--- a/src/lib/auth/verify.ts
+++ b/src/lib/auth/verify.ts
@@ -1,23 +1,25 @@
 import { SiweMessage } from 'siwe'
 
-const DOMAIN = process.env.NEXT_PUBLIC_APP_DOMAIN ?? 'localhost:3000'
-
 type VerifyResult =
   | { valid: true; address: string }
   | { valid: false; error: string }
 
+/** Verify a SIWE signature, binding it to expectedDomain — which callers must
+ *  derive from the incoming request host (not a hardcoded env value) so it
+ *  always matches the origin the wallet signed for. */
 export async function verifySiweMessage(
   message: string,
-  signature: string
+  signature: string,
+  expectedDomain: string
 ): Promise<VerifyResult> {
   try {
     const siweMessage = new SiweMessage(message)
 
-    if (siweMessage.domain !== DOMAIN) {
+    if (!expectedDomain || siweMessage.domain !== expectedDomain) {
       return { valid: false, error: 'Domain mismatch' }
     }
 
-    const result = await siweMessage.verify({ signature, domain: DOMAIN })
+    const result = await siweMessage.verify({ signature, domain: expectedDomain })
     if (!result.success) {
       return { valid: false, error: 'Signature verification failed' }
     }

--- a/src/lib/trustops/__tests__/collect.test.ts
+++ b/src/lib/trustops/__tests__/collect.test.ts
@@ -2,9 +2,13 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { collectTrustOpsOverview } from '../collect'
 
 const mockSelect = vi.fn()
+const fromCalls: string[] = []
 
 vi.mock('@/lib/supabase/admin', () => {
-  const mockFrom = vi.fn(() => ({ select: mockSelect }))
+  const mockFrom = vi.fn((table: string) => {
+    fromCalls.push(table)
+    return { select: mockSelect }
+  })
   return { supabaseAdmin: { from: mockFrom } }
 })
 
@@ -23,6 +27,7 @@ function chainable(data: unknown, count?: number) {
 
 beforeEach(() => {
   vi.clearAllMocks()
+  fromCalls.length = 0
 })
 
 describe('collectTrustOpsOverview', () => {
@@ -54,6 +59,8 @@ describe('collectTrustOpsOverview', () => {
     expect(result.elevatedRiskCount).toBe(1)
     expect(result.recentEvaluations).toEqual([])
     expect(result.collectedAt).toBeTruthy()
+    expect(fromCalls).toContain('evaluation_log')
+    expect(fromCalls).not.toContain('api_usage_log')
   })
 
   it('handles empty database', async () => {

--- a/src/lib/trustops/__tests__/log.test.ts
+++ b/src/lib/trustops/__tests__/log.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { recordEvaluation } from '../log'
+
+const mockInsert = vi.fn(() => Promise.resolve({ error: null }))
+const fromTables: string[] = []
+
+vi.mock('@/lib/supabase/admin', () => ({
+  supabaseAdmin: {
+    from: (table: string) => {
+      fromTables.push(table)
+      return { insert: mockInsert }
+    },
+  },
+}))
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  fromTables.length = 0
+})
+
+describe('recordEvaluation', () => {
+  it('inserts a row into evaluation_log with mapped columns', async () => {
+    await recordEvaluation({
+      chainId: 42220,
+      agentId: 5,
+      endpoint: '/api/v1/trust/evaluate',
+      preset: 'default_safety',
+      authMethod: 'x402',
+    })
+
+    expect(fromTables).toContain('evaluation_log')
+    expect(mockInsert).toHaveBeenCalledWith({
+      chain_id: 42220,
+      agent_id: 5,
+      endpoint: '/api/v1/trust/evaluate',
+      preset: 'default_safety',
+      auth_method: 'x402',
+    })
+  })
+
+  it('omits preset when not provided', async () => {
+    await recordEvaluation({
+      chainId: 1,
+      agentId: 2,
+      endpoint: '/api/v1/trust/evaluate',
+      authMethod: 'api_key',
+    })
+
+    expect(mockInsert).toHaveBeenCalledWith({
+      chain_id: 1,
+      agent_id: 2,
+      endpoint: '/api/v1/trust/evaluate',
+      preset: null,
+      auth_method: 'api_key',
+    })
+  })
+
+  it('does not throw when the insert fails (fire-and-forget)', async () => {
+    mockInsert.mockResolvedValueOnce({ error: { message: 'boom' } } as never)
+
+    await expect(
+      recordEvaluation({
+        chainId: 1,
+        agentId: 2,
+        endpoint: '/api/v1/trust/evaluate',
+        authMethod: 'api_key',
+      }),
+    ).resolves.toBeUndefined()
+  })
+})

--- a/src/lib/trustops/collect.ts
+++ b/src/lib/trustops/collect.ts
@@ -42,9 +42,8 @@ export async function collectTrustOpsOverview(): Promise<TrustOpsOverview> {
       .select('id, severity', { count: 'exact' })
       .is('resolved_at', null),
     supabaseAdmin
-      .from('api_usage_log')
+      .from('evaluation_log')
       .select('chain_id, agent_id, endpoint, called_at')
-      .like('endpoint', '%/trust/evaluate%')
       .order('called_at', { ascending: false })
       .limit(20),
   ])

--- a/src/lib/trustops/log.ts
+++ b/src/lib/trustops/log.ts
@@ -1,0 +1,26 @@
+import { supabaseAdmin } from '@/lib/supabase/admin'
+
+/**
+ * Record a trust evaluation call in the audit log.
+ * Called after an evaluation succeeds — fire-and-forget (non-blocking).
+ * Never throws: a logging failure must not break the evaluation response.
+ */
+export async function recordEvaluation(params: {
+  chainId: number
+  agentId: number
+  endpoint: string
+  preset?: string
+  authMethod: 'api_key' | 'x402'
+}): Promise<void> {
+  try {
+    await supabaseAdmin.from('evaluation_log').insert({
+      chain_id: params.chainId,
+      agent_id: params.agentId,
+      endpoint: params.endpoint,
+      preset: params.preset ?? null,
+      auth_method: params.authMethod,
+    })
+  } catch (e) {
+    console.error('Failed to record evaluation:', e)
+  }
+}

--- a/src/stores/auth.ts
+++ b/src/stores/auth.ts
@@ -3,13 +3,18 @@ import { create } from 'zustand'
 type AuthState = {
   address: string | null
   isConnected: boolean
+  /** True only after a successful SIWE sign-in (session cookie created). */
+  authenticated: boolean
   setAddress: (address: string) => void
+  setAuthenticated: (value: boolean) => void
   disconnect: () => void
 }
 
 export const useAuthStore = create<AuthState>()((set) => ({
   address: null,
   isConnected: false,
+  authenticated: false,
   setAddress: (address) => set({ address, isConnected: true }),
-  disconnect: () => set({ address: null, isConnected: false }),
+  setAuthenticated: (value) => set({ authenticated: value }),
+  disconnect: () => set({ address: null, isConnected: false, authenticated: false }),
 }))

--- a/supabase/migrations/20260701010000_trustops_evaluation_log.sql
+++ b/supabase/migrations/20260701010000_trustops_evaluation_log.sql
@@ -1,0 +1,30 @@
+-- TrustOps: evaluation audit log
+-- Append-only record of trust evaluation calls (/api/v1/trust/evaluate).
+-- Powers the TrustOps dashboard "recent evaluations" panel.
+
+CREATE TABLE evaluation_log (
+  id BIGSERIAL PRIMARY KEY,
+  chain_id INTEGER NOT NULL,
+  agent_id INTEGER NOT NULL,
+  endpoint TEXT NOT NULL,
+  preset TEXT,
+  auth_method TEXT NOT NULL CHECK (auth_method IN ('api_key', 'x402')),
+  called_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Recent-first ordering for the dashboard
+CREATE INDEX idx_evaluation_log_called ON evaluation_log (called_at DESC);
+
+-- Per-agent lookups
+CREATE INDEX idx_evaluation_log_agent ON evaluation_log (chain_id, agent_id);
+
+-- RLS: service_role writes/reads, no anon access
+ALTER TABLE evaluation_log ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "evaluation_log_no_anon"
+  ON evaluation_log FOR SELECT
+  USING (false);
+
+CREATE POLICY "evaluation_log_service_insert"
+  ON evaluation_log FOR INSERT
+  WITH CHECK (true);


### PR DESCRIPTION
## Problem

The **TrustOps** dashboard (`/discovery`) showed *"Failed to load TrustOps data"*. Root cause: `collectTrustOpsOverview()` queried `api_usage_log` for columns (`chain_id, agent_id, endpoint, called_at`) that never existed — that table is a per-key/day rate-limit counter (`id, api_key_id, usage_date, request_count`). PostgREST returned an error → the page threw.

There was also no per-call audit source: `/trust/evaluate` only bumped the rate-limit counter, so "recent evaluations" had no real data.

## Fix (SDD → TDD → EDD)

- **`evaluation_log` table** (migration `20260701010000`): append-only audit of trust evaluation calls. Indexed `called_at DESC` + per-agent. RLS service-only, no anon.
- **`recordEvaluation()`** helper — fire-and-forget, never throws.
- Wired into `/api/v1/trust/evaluate` for both `api_key` and `x402` auth.
- `collectTrustOpsOverview` now reads `evaluation_log`; `EvaluationLogEntry` type + UI unchanged.

## Verification

- 7/7 trustops tests green (3 new for `recordEvaluation`, +table asserts in `collect`).
- `tsc --noEmit` clean, `pnpm build` passes.
- Pre-existing unrelated failures (vendored zod v4 suite + `x402/config`) untouched.
- **Migration already applied to prod** (`ioxjqabngtannnfsueqa`); Local=Remote confirmed.

Wolfcito 🐾 @akawolfcito